### PR TITLE
💚 fix: exclude non-testable files to avoid false-positive CI coverage…

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -153,6 +153,39 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.10</version>
+				<configuration>
+					<excludes>
+						<!-- Main Application Class -->
+						<exclude>**/ScoutsProjectApplication.class</exclude>
+						
+						<!-- Configuration Classes -->
+						<exclude>**/config/**</exclude>
+						<exclude>**/infrastructure/security/SecurityConfig.class</exclude>
+						
+						<!-- DTOs (Data Transfer Objects) -->
+						<exclude>**/dto/**</exclude>
+						
+						<!-- Entity/Model Classes (JPA Entities with Lombok) -->
+						<exclude>**/model/**</exclude>
+						<exclude>**/organigram/**</exclude>
+						<exclude>**/medicalrecord/MedicalRecord.class</exclude>
+						<exclude>**/medicalrecord/MedicalRecord$*.class</exclude>
+						
+						<!-- Enums -->
+						<exclude>**/enums/**</exclude>
+						<exclude>**/shared/enums/**</exclude>
+						
+						<!-- Ports/Interfaces (no implementation logic) -->
+						<exclude>**/domain/port/**</exclude>
+						
+						<!-- Test/Mock Controllers (development only) -->
+						<exclude>**/web/controller/MockTestAuthzController.class</exclude>
+						<exclude>**/common/controller/TestController.class</exclude>
+						
+						<!-- Repository Interfaces (Spring Data JPA auto-implemented) -->
+						<exclude>**/repository/**</exclude>
+					</excludes>
+				</configuration>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
This pull request updates the JaCoCo code coverage configuration in the `pom.xml` file to exclude certain classes and packages from coverage reports. The goal is to focus code coverage metrics on business logic and exclude boilerplate, configuration, DTOs, and other classes that do not require direct testing.

**Code coverage configuration:**

* Added a `<configuration>` section to the `jacoco-maven-plugin` in `pom.xml` to exclude the following from coverage reports: the main application class, configuration classes, DTOs, entities/models, enums, ports/interfaces, test/mock controllers, and repository interfaces.