### PR TITLE
refactor: minor implementing enum for endpoints protection plus placeholders per group

### DIFF
--- a/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.security.config.Customizer.withDefaults;
+import static uao.edu.co.scouts_project.infrastructure.security.Role.*;
 
 @Configuration
 @EnableWebSecurity
@@ -27,15 +28,49 @@ public class SecurityConfig {
         return http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/swagger-ui/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**").permitAll()
-                        .requestMatchers("/swagger-ui.html").permitAll()
-                        .requestMatchers("/actuator/**").permitAll()
 
-                        .requestMatchers("/api/public").permitAll()
-                        .requestMatchers("/api/v1/mock/scouts/list").hasAuthority("SCOPE_read:scouts-list")
-                        .requestMatchers("/api/v1/mock/scouts/add/member").hasAuthority("SCOPE_write:scout-member")
-                        .requestMatchers("/api/v1/mock/scouts/member").hasAuthority("SCOPE_read:scout-member")
+                        .requestMatchers("/api/v1/mock/scouts/list").hasAnyRole(ACUDIENTE.name(), DEV_SUPPORT.name())
+                        .requestMatchers("/api/v1/mock/scouts/add/member").hasAnyRole(TESORERO.name())
+                        .requestMatchers("/api/v1/mock/scouts/member").hasAnyRole(DEV_SUPPORT.name())
+
+                        // Organigrama
+
+
+
+
+                        //
+                        // Datos básicos de miembros
+
+
+
+
+                        //
+                        // Acudientes
+
+
+
+
+                        //
+                        // Datos médicos
+
+
+
+
+                        //
+                        // Pagos
+
+
+
+
+                        //
+                        // Planes de adelanto
+
+
+
+
+                        //
+                        .anyRequest().permitAll()
+
                 )
                 .cors(withDefaults())
                 .oauth2ResourceServer(oauth2 -> oauth2

--- a/backend/src/main/java/uao/edu/co/scouts_project/web/controller/MockTestAuthzController.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/web/controller/MockTestAuthzController.java
@@ -15,7 +15,7 @@ public class MockTestAuthzController {
 
         String name = getCurrentUsername();
 
-        return format("Access for authenticated user with permission 'read:scouts-list', for user %s", name);
+        return format("Access for authenticated user with roles [ACUDIENTE, DEV_SUPPORT], for user %s", name);
     }
 
     @PostMapping("/add/member")
@@ -23,7 +23,7 @@ public class MockTestAuthzController {
 
         String name = getCurrentUsername();
 
-        return format("Access for authenticated user with permission 'write:scout-member', for user %s", name);
+        return format("Access for authenticated user with roles [TESORERO], for user %s", name);
     }
 
     @GetMapping("/member")
@@ -31,7 +31,7 @@ public class MockTestAuthzController {
 
         String name = getCurrentUsername();
 
-        return format("Access for authenticated user with permission 'read:scout-member', for user %s", name);
+        return format("Access for authenticated user with roles [DEV_SUPPORT], for user %s", name);
     }
 
     static String getCurrentUsername() {


### PR DESCRIPTION
This pull request updates the authorization logic for several endpoints in the mock scouts API, switching from OAuth2 scope-based permissions to role-based access control. It also updates the corresponding controller messages to reflect the new roles required for each endpoint.

**Authorization logic updates:**

* Changed endpoint authorization in `SecurityConfig.java` from `.hasAuthority("SCOPE_*")` to `.hasAnyRole(...)`, using roles defined in the `Role` enum for `/api/v1/mock/scouts/list`, `/api/v1/mock/scouts/add/member`, and `/api/v1/mock/scouts/member` endpoints.
* Added static imports for roles from `Role` to simplify role references in `SecurityConfig.java`.

**Controller response updates:**

* Updated response messages in `MockTestAuthzController.java` to mention the required roles instead of OAuth2 permissions for the affected endpoints.