### PR TITLE
feat: retrieve org_id from authenticated user in system

### DIFF
--- a/backend/src/main/java/uao/edu/co/scouts_project/domain/port/PermissionQueryPort.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/domain/port/PermissionQueryPort.java
@@ -10,4 +10,6 @@ import java.util.Set;
 public interface PermissionQueryPort {
     Set<String> getUserPermissions(String userId);
     List<String> getCurrentUserRoles();
+    // Nuevo método: retorna el claim org_id del usuario autenticado actual (JWT)
+    String getCurrentUserOrgId();
 }

--- a/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/auth0/Auth0PermissionAdapter.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/auth0/Auth0PermissionAdapter.java
@@ -12,6 +12,9 @@ import uao.edu.co.scouts_project.infrastructure.cache.PermissionCacheMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 
 import java.util.HashSet;
 import java.util.List;
@@ -120,6 +123,40 @@ public class Auth0PermissionAdapter implements PermissionQueryPort {
             log.error("Fallo inesperado consultando Auth0 para {}: {}", userId, e.getMessage());
         }
         return List.of();
+    }
+
+    @Override
+    public String getCurrentUserOrgId() {
+        try {
+            Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+            if (auth == null || !auth.isAuthenticated()) {
+                return "";
+            }
+            // Intento 1
+            Object principal = auth.getPrincipal();
+            if (principal instanceof Jwt jwt) {
+                String val = jwt.getClaimAsString("org_id");
+                return val == null ? "" : val.trim();
+            }
+
+            // Intento 2
+            if (auth instanceof JwtAuthenticationToken jat) {
+                Jwt jwt = jat.getToken();
+                if (jwt != null) {
+                    String val = jwt.getClaimAsString("org_id");
+                    return val == null ? "" : val.trim();
+                }
+            }
+
+            // Intento 3
+            if (principal instanceof java.util.Map<?,?> map) {
+                Object val = map.get("org_id");
+                return val == null ? "" : String.valueOf(val).trim();
+            }
+        } catch (Exception e) {
+            log.error("No fue posible extraer org_id del JWT actual: {}", e.getMessage());
+        }
+        return "";
     }
 
 }

--- a/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/security/SecurityConfig.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/security/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
 
                         .requestMatchers("/api/v1/sec/roles").authenticated()
+                        .requestMatchers("/api/v1/sec/org_id").authenticated()
 
                         .requestMatchers("/api/v1/mock/scouts/list").hasAnyRole(ACUDIENTE.name(), DEV_SUPPORT.name())
                         .requestMatchers("/api/v1/mock/scouts/add/member").hasAnyRole(TESORERO.name())

--- a/backend/src/main/java/uao/edu/co/scouts_project/web/controller/SecurityUtils.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/web/controller/SecurityUtils.java
@@ -22,4 +22,9 @@ public class SecurityUtils {
         return permissionQueryPort.getCurrentUserRoles();
     }
 
+    @GetMapping("/org_id")
+    public String getAuthenticatedUserOrgId() {
+        return permissionQueryPort.getCurrentUserOrgId();
+    }
+
 }


### PR DESCRIPTION
This pull request introduces a new endpoint to allow authenticated users to retrieve their `org_id` claim from the JWT token. The main changes include adding a new method to the permission query port, implementing the logic to extract `org_id` from the JWT in the Auth0 adapter, updating security configuration to secure the new endpoint, and exposing it via the web controller.

**New endpoint for retrieving authenticated user's organization ID:**

* Added `getCurrentUserOrgId()` method to the `PermissionQueryPort` interface, defining a contract for accessing the current user's organization ID claim.
* Implemented `getCurrentUserOrgId()` in `Auth0PermissionAdapter`, with logic to extract the `org_id` claim from the JWT using several approaches and error handling.
* Updated `SecurityConfig` to secure the new `/api/v1/sec/org_id` endpoint, requiring authentication.
* Added a new controller endpoint `/api/v1/sec/org_id` in `SecurityUtils` to expose the organization ID to authenticated users.

**Dependency updates:**

* Imported necessary Spring Security and JWT classes in `Auth0PermissionAdapter` to support JWT claim extraction.