### PR TITLE
feat: create users with any role on auth0

### DIFF
--- a/backend/src/main/java/uao/edu/co/scouts_project/application/service/Auth0ServiceImpl.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/application/service/Auth0ServiceImpl.java
@@ -98,18 +98,7 @@ public class Auth0ServiceImpl implements IAuth0Service {
 
     @Override
     public CreatedUserDTO createUserWithRole(CreateUserWithRoleCommandDTO request) {
-        // Validar que el rol no sea administrativo
         String roleName = request.getRole().toUpperCase();
-        
-        // Lista de roles administrativos que NO se pueden asignar
-        List<String> forbiddenRoles = Arrays.asList("ADMIN_GLOBAL", "ADMIN_GRUPO", "DEV_SUPPORT");
-        
-        if (forbiddenRoles.contains(roleName)) {
-            throw new UnauthorizedRoleAssignmentException(
-                "No está autorizado para asignar roles administrativos. " +
-                "Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
-            );
-        }
 
         // Convertir string a enum Role
         Role role;
@@ -122,15 +111,23 @@ public class Auth0ServiceImpl implements IAuth0Service {
             );
         }
 
+        // Validar que el rol NO sea administrativo
+        List<Role> forbiddenRoles = Arrays.asList(Role.ADMIN_GLOBAL, Role.ADMIN_GRUPO, Role.DEV_SUPPORT);
+        if (forbiddenRoles.contains(role)) {
+            throw new UnauthorizedRoleAssignmentException(
+                "No está autorizado para asignar roles administrativos. " +
+                "Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
+            );
+        }
+
         // Validar que el rol esté en la lista de permitidos
         List<Role> allowedRoles = Arrays.asList(
             Role.SCOUT, 
             Role.ACUDIENTE, 
             Role.TESORERO, 
-            Role.SCOUTER,
+            Role.SCOUTER, 
             Role.COMITE_ADMIN
         );
-        
         if (!allowedRoles.contains(role)) {
             throw new UnauthorizedRoleAssignmentException(
                 "El rol " + roleName + " no está permitido para este endpoint. " +

--- a/backend/src/main/java/uao/edu/co/scouts_project/application/service/Auth0ServiceImpl.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/application/service/Auth0ServiceImpl.java
@@ -4,15 +4,18 @@ package uao.edu.co.scouts_project.application.service;
 // import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserCommandDTO;
+import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserWithRoleCommandDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.CreatedUserDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.OrganizationSummaryDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.RoleSummaryDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.UserSummaryDTO;
+import uao.edu.co.scouts_project.domain.exception.auth0.UnauthorizedRoleAssignmentException;
 import uao.edu.co.scouts_project.domain.port.Auth0AdminPort;
 import uao.edu.co.scouts_project.domain.port.RoleMappingPort;
 import uao.edu.co.scouts_project.infrastructure.security.Role;
 // no checked exceptions in service; adapter throws runtime Auth0GatewayException
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -91,6 +94,75 @@ public class Auth0ServiceImpl implements IAuth0Service {
     @Override
     public UserSummaryDTO getUserInOrganization(String organizationId, String userId) {
         return adminPort.getUserInOrganization(organizationId, userId);
+    }
+
+    @Override
+    public CreatedUserDTO createUserWithRole(CreateUserWithRoleCommandDTO request) {
+        // Validar que el rol no sea administrativo
+        String roleName = request.getRole().toUpperCase();
+        
+        // Lista de roles administrativos que NO se pueden asignar
+        List<String> forbiddenRoles = Arrays.asList("ADMIN_GLOBAL", "ADMIN_GRUPO", "DEV_SUPPORT");
+        
+        if (forbiddenRoles.contains(roleName)) {
+            throw new UnauthorizedRoleAssignmentException(
+                "No está autorizado para asignar roles administrativos. " +
+                "Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
+            );
+        }
+
+        // Convertir string a enum Role
+        Role role;
+        try {
+            role = Role.valueOf(roleName);
+        } catch (IllegalArgumentException ex) {
+            throw new IllegalArgumentException(
+                "Rol inválido: " + roleName + ". " +
+                "Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
+            );
+        }
+
+        // Validar que el rol esté en la lista de permitidos
+        List<Role> allowedRoles = Arrays.asList(
+            Role.SCOUT, 
+            Role.ACUDIENTE, 
+            Role.TESORERO, 
+            Role.SCOUTER,
+            Role.COMITE_ADMIN
+        );
+        
+        if (!allowedRoles.contains(role)) {
+            throw new UnauthorizedRoleAssignmentException(
+                "El rol " + roleName + " no está permitido para este endpoint. " +
+                "Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
+            );
+        }
+
+        // Crear el comando base para crear usuario
+        CreateUserCommandDTO createCommand = new CreateUserCommandDTO(
+            request.getEmail(),
+            request.getPassword(),
+            request.getUsername()
+        );
+
+        // Paso 1: Crear usuario en Auth0
+        CreatedUserDTO createdUser = createUser(createCommand);
+        String userId = createdUser.getId();
+
+        try {
+            // Paso 2: Asociar a la organización del usuario autenticado (usa org_id del JWT)
+            addUserToOwnOrganization(userId);
+
+            // Paso 3: Asignar el rol especificado
+            assignRole(userId, role);
+
+            return createdUser;
+
+        } catch (Exception ex) {
+            // Si falla algún paso posterior a la creación, re-lanzar la excepción
+            // El usuario ya fue creado en Auth0
+            throw ex;
+        }
     }
 
 }

--- a/backend/src/main/java/uao/edu/co/scouts_project/application/service/IAuth0Service.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/application/service/IAuth0Service.java
@@ -1,6 +1,7 @@
 package uao.edu.co.scouts_project.application.service;
 
 import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserCommandDTO;
+import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserWithRoleCommandDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.CreatedUserDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.OrganizationSummaryDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.RoleSummaryDTO;
@@ -47,4 +48,23 @@ public interface IAuth0Service {
     void addUserToOwnOrganization(String userId);
 
     UserSummaryDTO getUserInOrganization(String organizationId, String userId);
+
+    /**
+     * Crea un usuario completo con un rol específico:
+     * 1. Crea el usuario en Auth0
+     * 2. Lo asocia a la organización del usuario autenticado (obtiene org_id del JWT)
+     * 3. Le asigna el rol especificado
+     * 
+     * Solo permite roles no administrativos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN
+     * NO permite: ADMIN_GLOBAL, ADMIN_GRUPO, DEV_SUPPORT
+     * 
+     * @param request Datos del usuario a crear incluyendo el rol
+     * @return CreatedUserDTO con la información del usuario creado
+     * @throws uao.edu.co.scouts_project.domain.exception.auth0.UserAlreadyMemberException si el usuario ya pertenece a la organización
+     * @throws uao.edu.co.scouts_project.domain.exception.auth0.UnauthorizedRoleAssignmentException si intenta asignar un rol no permitido
+     * @throws uao.edu.co.scouts_project.domain.exception.auth0.ResourceNotFoundException si no se encuentra el usuario o rol
+     * @throws IllegalArgumentException si los parámetros son inválidos
+     * @throws uao.edu.co.scouts_project.domain.exception.auth0.Auth0GatewayException si hay un error de comunicación con Auth0
+     */
+    CreatedUserDTO createUserWithRole(CreateUserWithRoleCommandDTO request);
 }

--- a/backend/src/main/java/uao/edu/co/scouts_project/domain/dto/auth0/CreateUserWithRoleCommandDTO.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/domain/dto/auth0/CreateUserWithRoleCommandDTO.java
@@ -1,0 +1,45 @@
+package uao.edu.co.scouts_project.domain.dto.auth0;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Schema(description = "Comando para crear un usuario con un rol específico")
+public class CreateUserWithRoleCommandDTO {
+
+    @Schema(description = "Correo electrónico del usuario", example = "usuario@example.com")
+    @Email(message = "email debe ser un correo válido")
+    @NotBlank(message = "email es obligatorio")
+    private String email;
+
+    @Schema(description = "Contraseña del usuario", example = "P4ssw0rd!", minLength = 8, maxLength = 64)
+    @NotBlank(message = "password es obligatorio")
+    @Size(min = 8, max = 64, message = "password debe tener entre 8 y 64 caracteres")
+    private String password;
+
+    @Schema(description = "Nombre de usuario", example = "juan.perez", minLength = 3, maxLength = 50)
+    @NotBlank(message = "username es obligatorio")
+    @Size(min = 3, max = 50, message = "username debe tener entre 3 y 50 caracteres")
+    private String username;
+
+    @Schema(
+        description = "Rol a asignar al usuario. Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN",
+        allowableValues = {"SCOUT", "ACUDIENTE", "TESORERO", "SCOUTER", "COMITE_ADMIN"},
+        example = "SCOUT"
+    )
+    @NotNull(message = "role es obligatorio")
+    @Pattern(
+        regexp = "^(SCOUT|ACUDIENTE|TESORERO|SCOUTER|COMITE_ADMIN)$",
+        message = "Rol inválido. Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
+    )
+    private String role;
+}

--- a/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/security/RoleConstants.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/infrastructure/security/RoleConstants.java
@@ -1,0 +1,84 @@
+package uao.edu.co.scouts_project.infrastructure.security;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Constantes relacionadas con roles y permisos.
+ * Centraliza las listas de roles permitidos/prohibidos para evitar duplicación.
+ */
+public final class RoleConstants {
+
+    private RoleConstants() {
+        // Clase de utilidad - no instanciable
+    }
+
+    /**
+     * Roles administrativos que NO pueden ser asignados por usuarios.
+     */
+    public static final List<Role> FORBIDDEN_ROLES = Arrays.asList(
+            Role.ADMIN_GLOBAL,
+            Role.ADMIN_GRUPO,
+            Role.DEV_SUPPORT
+    );
+
+    /**
+     * Roles que pueden ser asignados por administradores.
+     */
+    public static final List<Role> ASSIGNABLE_ROLES = Arrays.asList(
+            Role.SCOUT,
+            Role.ACUDIENTE,
+            Role.TESORERO,
+            Role.SCOUTER,
+            Role.COMITE_ADMIN
+    );
+
+    /**
+     * Nombres de roles asignables como String (para validación de DTO).
+     */
+    public static final String ASSIGNABLE_ROLES_PATTERN = "^(SCOUT|ACUDIENTE|TESORERO|SCOUTER|COMITE_ADMIN)$";
+
+    /**
+     * Lista de nombres de roles asignables separados por coma (para mensajes de error).
+     */
+    public static final String ASSIGNABLE_ROLES_STRING = "SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN";
+
+    /**
+     * Set de nombres de roles prohibidos como String (para validación rápida).
+     */
+    private static final Set<String> FORBIDDEN_ROLE_NAMES = FORBIDDEN_ROLES.stream()
+            .map(Enum::name)
+            .collect(Collectors.toSet());
+
+    /**
+     * Verifica si un rol es asignable.
+     *
+     * @param role El rol a verificar
+     * @return true si el rol es asignable, false en caso contrario
+     */
+    public static boolean isAssignable(Role role) {
+        return ASSIGNABLE_ROLES.contains(role);
+    }
+
+    /**
+     * Verifica si un rol es prohibido.
+     *
+     * @param role El rol a verificar
+     * @return true si el rol es prohibido, false en caso contrario
+     */
+    public static boolean isForbidden(Role role) {
+        return FORBIDDEN_ROLES.contains(role);
+    }
+
+    /**
+     * Verifica si un nombre de rol es prohibido.
+     *
+     * @param roleName El nombre del rol a verificar
+     * @return true si el rol es prohibido, false en caso contrario
+     */
+    public static boolean isForbiddenRoleName(String roleName) {
+        return FORBIDDEN_ROLE_NAMES.contains(roleName.toUpperCase());
+    }
+}

--- a/backend/src/main/java/uao/edu/co/scouts_project/web/controller/Auth0Controller.java
+++ b/backend/src/main/java/uao/edu/co/scouts_project/web/controller/Auth0Controller.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -16,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import uao.edu.co.scouts_project.domain.dto.auth0.CreatedUserDTO;
 import uao.edu.co.scouts_project.application.service.IAuth0Service;
 import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserCommandDTO;
+import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserWithRoleCommandDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.OrganizationSummaryDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.RoleSummaryDTO;
 import uao.edu.co.scouts_project.domain.dto.auth0.UserSummaryDTO;
@@ -24,6 +24,7 @@ import uao.edu.co.scouts_project.domain.exception.auth0.ResourceNotFoundExceptio
 import uao.edu.co.scouts_project.domain.exception.auth0.UnauthorizedRoleAssignmentException;
 import uao.edu.co.scouts_project.domain.exception.auth0.UserAlreadyMemberException;
 import uao.edu.co.scouts_project.infrastructure.security.Role;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.util.HashMap;
 import java.util.List;
@@ -329,6 +330,78 @@ public class Auth0Controller {
             body.put("causeMessage", cause.getMessage());
         }
         return body;
+    }
+
+    @PostMapping("/create-user")
+    @PreAuthorize("hasAnyRole('ADMIN_GRUPO', 'ADMIN_GLOBAL')")
+    @Operation(
+        summary = "Crea un usuario completo con rol específico (Solo ADMIN_GRUPO y ADMIN_GLOBAL)",
+        description = "Crea un usuario en Auth0, lo asocia a la organización del admin autenticado y le asigna el rol especificado. " +
+                      "Roles permitidos: SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN. " +
+                      "NO se pueden crear roles administrativos (ADMIN_GLOBAL, ADMIN_GRUPO, DEV_SUPPORT).",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "Usuario creado exitosamente", 
+                        content = @Content(schema = @Schema(implementation = CreatedUserDTO.class))),
+            @ApiResponse(responseCode = "400", description = "Solicitud inválida o rol no permitido"),
+            @ApiResponse(responseCode = "403", description = "No autorizado - Solo ADMIN_GRUPO y ADMIN_GLOBAL pueden usar este endpoint"),
+            @ApiResponse(responseCode = "409", description = "El usuario ya pertenece a la organización"),
+            @ApiResponse(responseCode = "502", description = "Error de integración con Auth0")
+        }
+    )
+    @RequestBody(
+        required = true, 
+        description = "Datos para crear el usuario con rol específico", 
+        content = @Content(schema = @Schema(implementation = CreateUserWithRoleCommandDTO.class))
+    )
+    public ResponseEntity<Object> createUserWithRole(
+            @Valid @org.springframework.web.bind.annotation.RequestBody CreateUserWithRoleCommandDTO request,
+            BindingResult bindingResult) {
+        try {
+            // Validar errores de binding
+            if (bindingResult.hasErrors()) {
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(validationErrorBody(bindingResult));
+            }
+
+            // Crear usuario con rol
+            CreatedUserDTO createdUser = auth0Service.createUserWithRole(request);
+
+            // Preparar respuesta exitosa
+            Map<String, Object> body = Map.of(
+                    "message", "Usuario creado exitosamente",
+                    "userId", createdUser.getId(),
+                    "email", createdUser.getEmail(),
+                    "username", createdUser.getUsername(),
+                    "role", request.getRole(),
+                    "user", createdUser
+            );
+            return ResponseEntity.ok(body);
+
+        } catch (UserAlreadyMemberException ex) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("message", "El usuario ya pertenece a la organización"));
+                    
+        } catch (UnauthorizedRoleAssignmentException ex) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(Map.of(
+                        "message", ex.getMessage(),
+                        "allowedRoles", "SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
+                    ));
+                    
+        } catch (ResourceNotFoundException ex) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("message", ex.getMessage()));
+                    
+        } catch (IllegalArgumentException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(Map.of(
+                        "message", ex.getMessage(),
+                        "allowedRoles", "SCOUT, ACUDIENTE, TESORERO, SCOUTER, COMITE_ADMIN"
+                    ));
+                    
+        } catch (Auth0GatewayException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                    .body(gatewayErrorBody(ex, "Fallo creando usuario con rol"));
+        }
     }
 
 }

--- a/backend/src/test/java/uao/edu/co/scouts_project/application/service/Auth0ServiceImplTest.java
+++ b/backend/src/test/java/uao/edu/co/scouts_project/application/service/Auth0ServiceImplTest.java
@@ -5,11 +5,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserCommandDTO;
+import uao.edu.co.scouts_project.domain.dto.auth0.CreateUserWithRoleCommandDTO;
+import uao.edu.co.scouts_project.domain.dto.auth0.CreatedUserDTO;
+import uao.edu.co.scouts_project.domain.exception.auth0.UnauthorizedRoleAssignmentException;
 import uao.edu.co.scouts_project.domain.port.Auth0AdminPort;
 import uao.edu.co.scouts_project.domain.port.RoleMappingPort;
 import uao.edu.co.scouts_project.infrastructure.security.Role;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -136,4 +140,198 @@ class Auth0ServiceImplTest {
         verifyNoInteractions(roleMappingPort);
         verify(adminPort, times(1)).assignRole(userId, directRoleId);
     }
+
+    // ========== TESTS PARA createUserWithRole() ==========
+
+    @Test
+    void testCreateUserWithRole_WithValidRole_CreatesUserSuccessfully() {
+        // Given
+        CreateUserWithRoleCommandDTO request = new CreateUserWithRoleCommandDTO(
+            "test@example.com",
+            "Password123!",
+            "testuser",
+            "SCOUT"
+        );
+        
+        CreatedUserDTO expectedUser = new CreatedUserDTO(
+            "auth0|123",
+            "test@example.com",
+            "testuser",
+            false
+        );
+        
+        when(adminPort.createUser(any(CreateUserCommandDTO.class))).thenReturn(expectedUser);
+        when(adminPort.userHasRoles("auth0|123")).thenReturn(false);
+        when(roleMappingPort.getAuth0RoleId(Role.SCOUT)).thenReturn("rol_scout_123");
+
+        // When
+        CreatedUserDTO result = service.createUserWithRole(request);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("auth0|123", result.getId());
+        assertEquals("test@example.com", result.getEmail());
+        
+        verify(adminPort, times(1)).createUser(any(CreateUserCommandDTO.class));
+        verify(adminPort, times(1)).addUserToOwnOrganization("auth0|123");
+        verify(adminPort, times(1)).userHasRoles("auth0|123");
+        verify(roleAssignmentValidator, times(1)).validateRoleAssignment(Role.SCOUT, false);
+        verify(roleMappingPort, times(1)).getAuth0RoleId(Role.SCOUT);
+        verify(adminPort, times(1)).assignRole("auth0|123", "rol_scout_123");
+    }
+
+    @Test
+    void testCreateUserWithRole_WithForbiddenRole_ADMIN_GLOBAL_ThrowsException() {
+        // Given
+        CreateUserWithRoleCommandDTO request = new CreateUserWithRoleCommandDTO(
+            "admin@example.com",
+            "Password123!",
+            "adminuser",
+            "ADMIN_GLOBAL"
+        );
+
+        // When/Then
+        UnauthorizedRoleAssignmentException exception = assertThrows(
+            UnauthorizedRoleAssignmentException.class,
+            () -> service.createUserWithRole(request)
+        );
+        
+        assertTrue(exception.getMessage().contains("No está autorizado para asignar roles administrativos"));
+        verify(adminPort, never()).createUser(any());
+    }
+
+    @Test
+    void testCreateUserWithRole_WithForbiddenRole_ADMIN_GRUPO_ThrowsException() {
+        // Given
+        CreateUserWithRoleCommandDTO request = new CreateUserWithRoleCommandDTO(
+            "admin@example.com",
+            "Password123!",
+            "adminuser",
+            "ADMIN_GRUPO"
+        );
+
+        // When/Then
+        UnauthorizedRoleAssignmentException exception = assertThrows(
+            UnauthorizedRoleAssignmentException.class,
+            () -> service.createUserWithRole(request)
+        );
+        
+        assertTrue(exception.getMessage().contains("No está autorizado para asignar roles administrativos"));
+        verify(adminPort, never()).createUser(any());
+    }
+
+    @Test
+    void testCreateUserWithRole_WithForbiddenRole_DEV_SUPPORT_ThrowsException() {
+        // Given
+        CreateUserWithRoleCommandDTO request = new CreateUserWithRoleCommandDTO(
+            "dev@example.com",
+            "Password123!",
+            "devuser",
+            "DEV_SUPPORT"
+        );
+
+        // When/Then
+        UnauthorizedRoleAssignmentException exception = assertThrows(
+            UnauthorizedRoleAssignmentException.class,
+            () -> service.createUserWithRole(request)
+        );
+        
+        assertTrue(exception.getMessage().contains("No está autorizado para asignar roles administrativos"));
+        verify(adminPort, never()).createUser(any());
+    }
+
+    @Test
+    void testCreateUserWithRole_WithInvalidRole_ThrowsIllegalArgumentException() {
+        // Given
+        CreateUserWithRoleCommandDTO request = new CreateUserWithRoleCommandDTO(
+            "test@example.com",
+            "Password123!",
+            "testuser",
+            "INVALID_ROLE"
+        );
+
+        // When/Then
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> service.createUserWithRole(request)
+        );
+        
+        assertTrue(exception.getMessage().contains("Rol inválido"));
+        assertTrue(exception.getMessage().contains("INVALID_ROLE"));
+        verify(adminPort, never()).createUser(any());
+    }
+
+    @Test
+    void testCreateUserWithRole_WithAllAllowedRoles_Succeeds() {
+        // Given
+        String[] allowedRoles = {"SCOUT", "ACUDIENTE", "TESORERO", "SCOUTER", "COMITE_ADMIN"};
+        
+        for (String roleName : allowedRoles) {
+            CreateUserWithRoleCommandDTO request = new CreateUserWithRoleCommandDTO(
+                "test@example.com",
+                "Password123!",
+                "testuser",
+                roleName
+            );
+            
+            CreatedUserDTO expectedUser = new CreatedUserDTO(
+                "auth0|123",
+                "test@example.com",
+                "testuser",
+                false
+            );
+            
+            Role role = Role.valueOf(roleName);
+            
+            when(adminPort.createUser(any(CreateUserCommandDTO.class))).thenReturn(expectedUser);
+            when(adminPort.userHasRoles("auth0|123")).thenReturn(false);
+            when(roleMappingPort.getAuth0RoleId(role)).thenReturn("rol_" + roleName);
+
+            // When
+            CreatedUserDTO result = service.createUserWithRole(request);
+
+            // Then
+            assertNotNull(result);
+            assertEquals("auth0|123", result.getId());
+            
+            verify(adminPort).createUser(any(CreateUserCommandDTO.class));
+            verify(adminPort).addUserToOwnOrganization("auth0|123");
+            verify(adminPort).userHasRoles("auth0|123");
+            verify(roleAssignmentValidator).validateRoleAssignment(role, false);
+            verify(roleMappingPort).getAuth0RoleId(role);
+            verify(adminPort).assignRole("auth0|123", "rol_" + roleName);
+            
+            reset(adminPort, roleMappingPort, roleAssignmentValidator);
+        }
+    }
+
+    @Test
+    void testCreateUserWithRole_CaseInsensitive_WorksCorrectly() {
+        // Given - lowercase role
+        CreateUserWithRoleCommandDTO request = new CreateUserWithRoleCommandDTO(
+            "test@example.com",
+            "Password123!",
+            "testuser",
+            "scout"  // lowercase
+        );
+        
+        CreatedUserDTO expectedUser = new CreatedUserDTO(
+            "auth0|123",
+            "test@example.com",
+            "testuser",
+            false
+        );
+        
+        when(adminPort.createUser(any(CreateUserCommandDTO.class))).thenReturn(expectedUser);
+        when(adminPort.userHasRoles("auth0|123")).thenReturn(false);
+        when(roleMappingPort.getAuth0RoleId(Role.SCOUT)).thenReturn("rol_scout_123");
+
+        // When
+        CreatedUserDTO result = service.createUserWithRole(request);
+
+        // Then
+        assertNotNull(result);
+        verify(roleMappingPort, times(1)).getAuth0RoleId(Role.SCOUT);
+    }
 }
+


### PR DESCRIPTION
# 🧩 PR: Generic User Creation with Role Assignment

##  Description

Adds `POST /api/v1/auth0/create-user` endpoint for flexible user creation with role assignment.

**Changes:**
- New endpoint allowing `ADMIN_GRUPO` and `ADMIN_GLOBAL` to create users with specific roles
- `CreateUserWithRoleCommandDTO` with Lombok annotations
- Role validation: allows `SCOUT`, `ACUDIENTE`, `TESORERO`, `SCOUTER`, `COMITE_ADMIN`
- Blocks admin roles: `ADMIN_GLOBAL`, `ADMIN_GRUPO`, `DEV_SUPPORT`

**Flow:** Create user → Associate to org (from JWT) → Assign role

---

## 🔍 Type of Change

- [x] **Feature** – New capability

---

## 🚀 How to Test

```bash
cd backend
./mvnw test
./mvnw spring-boot:run
```

**Test at:** `http://localhost:8080/swagger-ui.html` → Auth0 Management → `/create-user`

**Request example:**
```json
{
  "email": "user@example.com",
  "password": "Password123!",
  "username": "username",
  "role": "SCOUT"
}
```

**Expected:** 200 OK  
**Try forbidden role:** `"role": "ADMIN_GLOBAL"` → 403 Forbidden

---

## ✅ Checklist

- [x] Tests passing
- [x] Swagger docs updated
- [x] No merge conflicts
- [x] Self-reviewed

---

## 🧠 Notes

- Uses Lombok (`@Data`, `@AllArgsConstructor`, `@NoArgsConstructor`)
- Triple validation: DTO regex → Service logic → Enum
- Org ID auto-extracted from JWT (secure)
