### PR TITLE
feat: slug validation, form improvements, and backend compatibility fixes for group management

### DIFF
--- a/frontend/src/api/groupsApi.ts
+++ b/frontend/src/api/groupsApi.ts
@@ -190,9 +190,9 @@ export const getTopGroupsByMembers = async () => {
 }
 
 // Validar si un slug de grupo ya existe
-export const validateGroupSlug = async (tenantId: string, slug: string) => {
+export const validateGroupSlug = async (slug: string) => {
   const response = await api.get<{ slug: string; valid: boolean; reason: string | null; message: string | null }>(
-    `/tenants/${tenantId}/groups/slug/validate`,
+    `/tenants/A/groups/slug/validate`,
     { params: { slug } }
   );
   return response.data;

--- a/frontend/src/api/groupsApi.ts
+++ b/frontend/src/api/groupsApi.ts
@@ -188,3 +188,12 @@ export const getTopGroupsByMembers = async () => {
   const response = await api.get<TopGroupByMembersDTO[]>("/statistics/groups/most-members");
   return response.data;
 }
+
+// Validar si un slug de grupo ya existe
+export const validateGroupSlug = async (tenantId: string, slug: string) => {
+  const response = await api.get<{ slug: string; valid: boolean; reason: string | null; message: string | null }>(
+    `/tenants/${tenantId}/groups/slug/validate`,
+    { params: { slug } }
+  );
+  return response.data;
+}

--- a/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
+++ b/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Button, Input, Label, ImageUpload } from "@/components/ui";
 import {
@@ -29,8 +30,12 @@ import { es } from "date-fns/locale";
 import {
   createGroupAction,
   fetchGroupsWithAdminsAction,
+  validateGroupSlugAction,
 } from "@/store/groups/groupsActions";
-import { clearNotification } from "@/store/groups/groupsSlice";
+import {
+  clearNotification,
+  resetSlugValidation,
+} from "@/store/groups/groupsSlice";
 import type { CreateGroupDTO } from "@/types/group.type";
 import { useGroup } from "@/hooks/useGroup";
 import { uploadPhotoFile } from "@/lib/imageUtils";
@@ -51,7 +56,7 @@ export default function CreateGroupModal({
     status: "ACTIVE",
   });
   const dispatch = useDispatch<AppDispatch>();
-  const { message, error } = useGroup();
+  const { message, error, slugValidation } = useGroup();
 
   useEffect(() => {
     if (message) {
@@ -71,8 +76,23 @@ export default function CreateGroupModal({
         isActive: true,
         status: "ACTIVE",
       });
+      dispatch(resetSlugValidation());
     }
-  }, [open]);
+  }, [open, dispatch]);
+
+  const validateSlug = (slug: string) => {
+    if (!slug || slug.trim() === "") {
+      dispatch(resetSlugValidation());
+      return;
+    }
+
+    const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    if (!slugRegex.test(slug)) {
+      return;
+    }
+
+    dispatch(validateGroupSlugAction({ tenantId: "A", slug }));
+  };
 
   const handleChange = <K extends keyof CreateGroupDTO>(
     field: K,
@@ -90,6 +110,12 @@ export default function CreateGroupModal({
         status: String(value),
         isActive: String(value) === "ACTIVE",
       }));
+    } else if (field === "slug") {
+      setForm((prev) => ({ ...prev, [field]: value }));
+      const timeoutId = setTimeout(() => {
+        validateSlug(String(value));
+      }, 500);
+      return () => clearTimeout(timeoutId);
     } else {
       setForm((prev) => ({ ...prev, [field]: value }));
     }
@@ -103,15 +129,39 @@ export default function CreateGroupModal({
       return;
     }
 
-    const generatedSlug = form.name
-      .toLowerCase()
-      .normalize("NFD")
-      .replace(/[\u0300-\u036f]/g, "")
-      .replace(/\s+/g, "-")
-      .replace(/[^a-z0-9-]/g, "");
+    if (!form.slug || form.slug.trim() === "") {
+      toast.error("El slug es requerido");
+      return;
+    }
+
+    // Validar formato del slug
+    const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    if (!slugRegex.test(form.slug)) {
+      toast.error(
+        "El slug solo puede contener letras minúsculas, números y guiones"
+      );
+      return;
+    }
+
+    // Validar que el slug esté disponible
+    if (slugValidation.error || slugValidation.isAvailable === false) {
+      toast.error("El slug no está disponible o hay un error en la validación");
+      return;
+    }
+
+    if (slugValidation.isValidating) {
+      toast.error("Esperando validación del slug...");
+      return;
+    }
 
     if (!form.email || form.email.trim() === "") {
       toast.error("El correo electrónico es requerido");
+      return;
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(form.email)) {
+      toast.error("El formato del correo electrónico no es válido");
       return;
     }
 
@@ -123,7 +173,7 @@ export default function CreateGroupModal({
 
     const groupData = {
       tenant_id: "A", // Tenant por defecto para grupos globales
-      slug: generatedSlug,
+      slug: form.slug ?? "",
       name: form.name,
       district: form.district || null,
       identifier_number: form.identifierNumber || null,
@@ -159,6 +209,9 @@ export default function CreateGroupModal({
           <DialogTitle className="text-2xl font-bold text-primary">
             Crear Grupo
           </DialogTitle>
+          <DialogDescription>
+            Completa la información para crear un nuevo grupo scout
+          </DialogDescription>
         </DialogHeader>
         <div className="p-4 bg-white rounded-md border border-slate-200">
           <h3 className="text-lg font-medium text-gray-700 mb-4">
@@ -173,6 +226,41 @@ export default function CreateGroupModal({
                 onChange={(e) => handleChange("name", e.target.value)}
                 placeholder="Nombre del grupo"
               />
+            </div>
+            <div>
+              <Label className="text-sm text-accent-foreground">Slug *</Label>
+              <Input
+                className={`mt-1 w-full ${
+                  slugValidation.error || slugValidation.isAvailable === false
+                    ? "border-red-500"
+                    : slugValidation.isAvailable === true
+                    ? "border-green-500"
+                    : ""
+                }`}
+                value={form.slug ?? ""}
+                onChange={(e) => handleChange("slug", e.target.value)}
+                placeholder="slug-del-grupo"
+              />
+              {slugValidation.isValidating && (
+                <p className="text-xs text-gray-500 mt-1">Validando...</p>
+              )}
+              {slugValidation.error && (
+                <p className="text-xs text-red-500 mt-1">
+                  {slugValidation.error}
+                </p>
+              )}
+              {!slugValidation.error &&
+                slugValidation.isAvailable === false && (
+                  <p className="text-xs text-red-500 mt-1">
+                    Este slug ya está en uso
+                  </p>
+                )}
+              {!slugValidation.error && slugValidation.isAvailable === true && (
+                <p className="text-xs text-green-600 mt-1">Slug disponible</p>
+              )}
+              <p className="text-xs text-gray-500 mt-1">
+                Solo letras minúsculas, números y guiones
+              </p>
             </div>
             <div>
               <Label className="text-sm text-accent-foreground">Distrito</Label>
@@ -193,7 +281,7 @@ export default function CreateGroupModal({
                 onChange={(e) =>
                   handleChange("identifierNumber", e.target.value)
                 }
-                placeholder="NIT u otro identificador"
+                placeholder="Identificador"
               />
             </div>
             <div>
@@ -218,7 +306,7 @@ export default function CreateGroupModal({
             </div>
             <div>
               <Label className="text-sm text-accent-foreground">
-                Correo electrónico
+                Correo electrónico *
               </Label>
               <Input
                 type="email"
@@ -251,6 +339,9 @@ export default function CreateGroupModal({
                 <PopoverContent className="w-auto p-0" align="start">
                   <Calendar
                     mode="single"
+                    captionLayout="dropdown"
+                    fromYear={1900}
+                    toYear={new Date().getFullYear()}
                     selected={
                       form.foundedIn ? new Date(form.foundedIn) : undefined
                     }
@@ -260,7 +351,9 @@ export default function CreateGroupModal({
                       }
                     }}
                     disabled={(date) => date > new Date()}
-                    defaultMonth={form.foundedIn ? new Date(form.foundedIn) : undefined}
+                    defaultMonth={
+                      form.foundedIn ? new Date(form.foundedIn) : undefined
+                    }
                     initialFocus
                     locale={es}
                   />
@@ -274,22 +367,6 @@ export default function CreateGroupModal({
                 value={form.motto ?? ""}
                 onChange={(e) => handleChange("motto", e.target.value)}
                 placeholder="Lema del grupo"
-              />
-            </div>
-            <div>
-              <ImageUpload
-                label="Logo del grupo"
-                value={form.logoObjectId ?? ""}
-                onChange={(objectId) => handleChange("logoObjectId", objectId)}
-                onUpload={uploadPhotoFile}
-              />
-            </div>
-            <div>
-              <ImageUpload
-                label="Pañoleta del grupo"
-                value={form.scarfObjectId ?? ""}
-                onChange={(objectId) => handleChange("scarfObjectId", objectId)}
-                onUpload={uploadPhotoFile}
               />
             </div>
             <div>
@@ -307,7 +384,22 @@ export default function CreateGroupModal({
                 </SelectContent>
               </Select>
             </div>
-
+            <div>
+              <ImageUpload
+                label="Logo del grupo"
+                value={form.logoObjectId ?? ""}
+                onChange={(objectId) => handleChange("logoObjectId", objectId)}
+                onUpload={uploadPhotoFile}
+              />
+            </div>
+            <div>
+              <ImageUpload
+                label="Pañoleta del grupo"
+                value={form.scarfObjectId ?? ""}
+                onChange={(objectId) => handleChange("scarfObjectId", objectId)}
+                onUpload={uploadPhotoFile}
+              />
+            </div>
             <div className="md:col-span-2">
               <Label className="text-sm text-accent-foreground">Misión</Label>
               <Textarea

--- a/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
+++ b/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
@@ -134,7 +134,6 @@ export default function CreateGroupModal({
       return;
     }
 
-    // Validar formato del slug
     const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
     if (!slugRegex.test(form.slug)) {
       toast.error(
@@ -143,9 +142,11 @@ export default function CreateGroupModal({
       return;
     }
 
-    // Validar que el slug esté disponible
     if (slugValidation.error || slugValidation.isAvailable === false) {
-      toast.error("El slug no está disponible o hay un error en la validación");
+      toast.error(
+        slugValidation.error ||
+          "El slug no está disponible o hay un error en la validación"
+      );
       return;
     }
 

--- a/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
+++ b/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
@@ -150,7 +150,7 @@ export default function CreateGroupModal({
     }
 
     if (slugValidation.isValidating) {
-      toast.error("Esperando validación del slug...");
+      toast.info("Esperando validación del slug...");
       return;
     }
 

--- a/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
+++ b/frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx
@@ -86,12 +86,7 @@ export default function CreateGroupModal({
       return;
     }
 
-    const slugRegex = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-    if (!slugRegex.test(slug)) {
-      return;
-    }
-
-    dispatch(validateGroupSlugAction({ tenantId: "A", slug }));
+    dispatch(validateGroupSlugAction({ slug }));
   };
 
   const handleChange = <K extends keyof CreateGroupDTO>(

--- a/frontend/src/app/routes/admin-global/Grupos/detalles/GroupEditModal.tsx
+++ b/frontend/src/app/routes/admin-global/Grupos/detalles/GroupEditModal.tsx
@@ -7,6 +7,7 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from "@/components/ui/dialog";
 import { Button, Input, Label, ImageUpload } from "@/components/ui";
 import {
@@ -26,11 +27,12 @@ import { Calendar } from "@/components/ui/calendar";
 import { Calendar as CalendarIcon } from "lucide-react";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import { updateGroupAction, fetchGroupsWithAdminsAction } from "@/store/groups/groupsActions";
+import {
+  updateGroupAction,
+  fetchGroupsWithAdminsAction,
+} from "@/store/groups/groupsActions";
 import { clearNotification } from "@/store/groups/groupsSlice";
-import type {
-  UpdateGroupDTO,
-} from "@/types/group.type";
+import type { UpdateGroupDTO } from "@/types/group.type";
 import { useGroup } from "@/hooks/useGroup";
 import { uploadPhotoFile } from "@/lib/imageUtils";
 
@@ -76,18 +78,21 @@ export default function GroupEditModal({
 
   if (!group) return null;
 
-  const handleChange = <K extends keyof UpdateGroupDTO>(field: K, value: UpdateGroupDTO[K]) => {
-    if (field === 'isActive') {
+  const handleChange = <K extends keyof UpdateGroupDTO>(
+    field: K,
+    value: UpdateGroupDTO[K]
+  ) => {
+    if (field === "isActive") {
       setForm((prev) => ({
         ...prev,
         isActive: Boolean(value),
-        status: value ? 'ACTIVE' : 'INACTIVE',
+        status: value ? "ACTIVE" : "INACTIVE",
       }));
-    } else if (field === 'status') {
+    } else if (field === "status") {
       setForm((prev) => ({
         ...prev,
         status: String(value),
-        is_active: String(value) === 'ACTIVE',
+        is_active: String(value) === "ACTIVE",
       }));
     } else {
       setForm((prev) => ({ ...prev, [field]: value }));
@@ -104,42 +109,56 @@ export default function GroupEditModal({
       return;
     }
 
-    const updates: Partial<UpdateGroupDTO & { is_active?: boolean }> = Object.fromEntries(
-      (Object.keys(form) as Array<keyof UpdateGroupDTO>)
-        .filter((key) => {
-          // Excluir logo y scarf del update general, se manejan por separado
-          if (key === 'logoObjectId' || key === 'scarfObjectId') return false;
-          return form[key] !== group[key];
-        })
-        .map((key) => [key, form[key]])
-    );
-    
-    if ('status' in updates) {
-      updates['status'] = form.status === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE';
-      updates['isActive'] = form.status === 'ACTIVE';
+    if (form.email && form.email.trim() !== "") {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(form.email)) {
+        toast.error("El formato del correo electrónico no es válido");
+        return;
+      }
     }
-    if ('isActive' in updates && !('status' in updates)) {
-      updates['isActive'] = Boolean(form.isActive);
-      updates['status'] = form.isActive ? 'ACTIVE' : 'INACTIVE';
-      delete updates['is_active'];
-    }
-    if ('isActive' in updates) {
-      delete updates['isActive'];
-    }
+
+    const updates: Record<string, unknown> = {};
+
+    (Object.keys(form) as Array<keyof UpdateGroupDTO>).forEach((key) => {
+      if (key === "logoObjectId" || key === "scarfObjectId") return;
+
+      if (form[key] !== group[key]) {
+        switch (key) {
+          case "identifierNumber":
+            updates["identifier_number"] = form[key];
+            break;
+          case "foundedIn":
+            updates["founded_in"] = form[key];
+            break;
+          case "socialLinks":
+            updates["social_links"] = form[key];
+            break;
+          case "isActive":
+            updates["is_active"] = Boolean(form[key]);
+            updates["status"] = form[key] ? "ACTIVE" : "INACTIVE";
+            break;
+          case "status":
+            updates["status"] = form[key] === "ACTIVE" ? "ACTIVE" : "INACTIVE";
+            updates["is_active"] = form[key] === "ACTIVE";
+            break;
+          default:
+            updates[key] = form[key];
+        }
+      }
+    });
 
     if (Object.keys(updates).length > 0) {
       const action = await dispatch(
         updateGroupAction({ tenantId, groupSlug, updates })
       );
       if (!updateGroupAction.fulfilled.match(action)) {
-        return; 
+        return;
       }
     }
 
-    // Actualizar logo si cambió
     if (logoChanged && form.logoObjectId) {
       try {
-        const { updateGroupLogo } = await import('@/api/groupsApi');
+        const { updateGroupLogo } = await import("@/api/groupsApi");
         await updateGroupLogo(tenantId, groupSlug, form.logoObjectId);
         toast.success("Logo actualizado correctamente");
       } catch (err) {
@@ -149,10 +168,9 @@ export default function GroupEditModal({
       }
     }
 
-    // Actualizar scarf si cambió
     if (scarfChanged && form.scarfObjectId) {
       try {
-        const { updateGroupScarf } = await import('@/api/groupsApi');
+        const { updateGroupScarf } = await import("@/api/groupsApi");
         await updateGroupScarf(tenantId, groupSlug, form.scarfObjectId);
         toast.success("Pañoleta actualizada correctamente");
       } catch (err) {
@@ -162,7 +180,6 @@ export default function GroupEditModal({
       }
     }
 
-    // Recargar datos
     await dispatch(fetchGroupsWithAdminsAction());
     if (onSave) onSave({ ...group, ...form });
     onOpenChange(false);
@@ -175,6 +192,9 @@ export default function GroupEditModal({
           <DialogTitle className="text-2xl font-bold text-primary">
             Editar Grupo
           </DialogTitle>
+          <DialogDescription>
+            Modifica la información del grupo scout
+          </DialogDescription>
         </DialogHeader>
         <div className="p-4 bg-white rounded-md border border-slate-200">
           <h3 className="text-lg font-medium text-gray-700 mb-4">
@@ -188,6 +208,17 @@ export default function GroupEditModal({
                 value={form.name ?? ""}
                 onChange={(e) => handleChange("name", e.target.value)}
               />
+            </div>
+            <div>
+              <Label className="text-sm text-accent-foreground">Slug</Label>
+              <Input
+                className="mt-1 w-full bg-white"
+                value={form.slug ?? ""}
+                onChange={(e) => handleChange("slug", e.target.value)}
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Solo letras minúsculas, números y guiones
+              </p>
             </div>
             <div>
               <Label className="text-sm text-accent-foreground">Distrito</Label>
@@ -204,11 +235,15 @@ export default function GroupEditModal({
               <Input
                 className="mt-1 w-full"
                 value={form.identifierNumber ?? ""}
-                onChange={(e) => handleChange("identifierNumber", e.target.value)}
+                onChange={(e) =>
+                  handleChange("identifierNumber", e.target.value)
+                }
               />
             </div>
             <div>
-              <Label className="text-sm text-accent-foreground">Dirección</Label>
+              <Label className="text-sm text-accent-foreground">
+                Dirección
+              </Label>
               <Input
                 className="mt-1 w-full"
                 value={form.address ?? ""}
@@ -248,21 +283,33 @@ export default function GroupEditModal({
                     {form.foundedIn ? (
                       format(new Date(form.foundedIn), "PPP", { locale: es })
                     ) : (
-                      <span className="text-muted-foreground">Seleccionar fecha</span>
+                      <span className="text-muted-foreground">
+                        Seleccionar fecha
+                      </span>
                     )}
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0" align="start">
                   <Calendar
                     mode="single"
-                    selected={form.foundedIn ? new Date(form.foundedIn) : undefined}
+                    captionLayout="dropdown"
+                    fromYear={1900}
+                    toYear={new Date().getFullYear()}
+                    selected={
+                      form.foundedIn ? new Date(form.foundedIn) : undefined
+                    }
                     onSelect={(date) => {
                       if (date) {
-                        handleChange("foundedIn", date as unknown as UpdateGroupDTO["foundedIn"]);
+                        handleChange(
+                          "foundedIn",
+                          date as unknown as UpdateGroupDTO["foundedIn"]
+                        );
                       }
                     }}
                     disabled={(date) => date > new Date()}
-                    defaultMonth={form.foundedIn ? new Date(form.foundedIn) : undefined}
+                    defaultMonth={
+                      form.foundedIn ? new Date(form.foundedIn) : undefined
+                    }
                     initialFocus
                     locale={es}
                   />
@@ -276,6 +323,21 @@ export default function GroupEditModal({
                 value={form.motto ?? ""}
                 onChange={(e) => handleChange("motto", e.target.value)}
               />
+            </div>
+            <div>
+              <Label className="text-sm text-accent-foreground">Estado</Label>
+              <Select
+                value={form.status ?? group.status ?? "INACTIVE"}
+                onValueChange={(val) => handleChange("status", val)}
+              >
+                <SelectTrigger className="mt-1 w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="ACTIVE">Activo</SelectItem>
+                  <SelectItem value="INACTIVE">Inactivo</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
             <div>
               <ImageUpload
@@ -298,21 +360,6 @@ export default function GroupEditModal({
                 }}
                 onUpload={uploadPhotoFile}
               />
-            </div>
-            <div>
-              <Label className="text-sm text-accent-foreground">Estado</Label>
-              <Select
-                value={form.status ?? group.status ?? 'INACTIVE'}
-                onValueChange={(val) => handleChange('status', val)}
-              >
-                <SelectTrigger className="mt-1 w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="ACTIVE">Activo</SelectItem>
-                  <SelectItem value="INACTIVE">Inactivo</SelectItem>
-                </SelectContent>
-              </Select>
             </div>
 
             <div className="md:col-span-2">
@@ -349,9 +396,13 @@ export default function GroupEditModal({
                   <Input
                     className="mt-1"
                     placeholder="https://ejemplo.com"
-                    value={(form.socialLinks as Record<string, string>)?.website ?? ""}
+                    value={
+                      (form.socialLinks as Record<string, string>)?.website ??
+                      ""
+                    }
                     onChange={(e) => {
-                      const currentLinks = (form.socialLinks as Record<string, string>) || {};
+                      const currentLinks =
+                        (form.socialLinks as Record<string, string>) || {};
                       handleChange("socialLinks", {
                         ...currentLinks,
                         website: e.target.value,
@@ -364,9 +415,13 @@ export default function GroupEditModal({
                   <Input
                     className="mt-1"
                     placeholder="https://facebook.com/..."
-                    value={(form.socialLinks as Record<string, string>)?.facebook ?? ""}
+                    value={
+                      (form.socialLinks as Record<string, string>)?.facebook ??
+                      ""
+                    }
                     onChange={(e) => {
-                      const currentLinks = (form.socialLinks as Record<string, string>) || {};
+                      const currentLinks =
+                        (form.socialLinks as Record<string, string>) || {};
                       handleChange("socialLinks", {
                         ...currentLinks,
                         facebook: e.target.value,
@@ -379,9 +434,13 @@ export default function GroupEditModal({
                   <Input
                     className="mt-1"
                     placeholder="https://instagram.com/..."
-                    value={(form.socialLinks as Record<string, string>)?.instagram ?? ""}
+                    value={
+                      (form.socialLinks as Record<string, string>)?.instagram ??
+                      ""
+                    }
                     onChange={(e) => {
-                      const currentLinks = (form.socialLinks as Record<string, string>) || {};
+                      const currentLinks =
+                        (form.socialLinks as Record<string, string>) || {};
                       handleChange("socialLinks", {
                         ...currentLinks,
                         instagram: e.target.value,

--- a/frontend/src/store/groups/groupsActions.ts
+++ b/frontend/src/store/groups/groupsActions.ts
@@ -1,6 +1,20 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { AxiosError } from "axios";
-import { getGroup, getGroups, updateGroup, createGroup, getMembersCountByGroup, getTotalMembersCount, getActiveGroupsCount, getInactiveGroupsCount, getTopGroupsByMembers, getGroupsWithAdmins, createGroupAdmin, createGroupAdminWithConnection } from "@/api/groupsApi";
+import {
+  getGroup,
+  getGroups,
+  updateGroup,
+  createGroup,
+  getMembersCountByGroup,
+  getTotalMembersCount,
+  getActiveGroupsCount,
+  getInactiveGroupsCount,
+  getTopGroupsByMembers,
+  getGroupsWithAdmins,
+  createGroupAdmin,
+  createGroupAdminWithConnection,
+  validateGroupSlug,
+} from "@/api/groupsApi";
 import type {
   GroupResponseDTO as Group,
   UpdateGroupDTO,
@@ -67,62 +81,75 @@ export const fetchGroupsWithAdminsAction = createAsyncThunk<
   GroupWithAdminBackendDTO[],
   void,
   { rejectValue: string }
->(
-  "groups/fetchWithAdmins",
-  async (_, { rejectWithValue }) => {
-    try {
-      const groupsWithAdmins = await getGroupsWithAdmins();
-      return groupsWithAdmins;
-    } catch (error: unknown) {
-      const axiosError = error as AxiosError;
-      const errorData = axiosError.response?.data as { error?: string; message?: string };
-      const errorMessage = errorData?.error 
-        || errorData?.message 
-        || `Error ${axiosError.response?.status || 'desconocido'} al obtener los grupos con administradores`;
-      
-      return rejectWithValue(errorMessage);
-    }
+>("groups/fetchWithAdmins", async (_, { rejectWithValue }) => {
+  try {
+    const groupsWithAdmins = await getGroupsWithAdmins();
+    return groupsWithAdmins;
+  } catch (error: unknown) {
+    const axiosError = error as AxiosError;
+    const errorData = axiosError.response?.data as {
+      error?: string;
+      message?: string;
+    };
+    const errorMessage =
+      errorData?.error ||
+      errorData?.message ||
+      `Error ${
+        axiosError.response?.status || "desconocido"
+      } al obtener los grupos con administradores`;
+
+    return rejectWithValue(errorMessage);
   }
-);
+});
 
 // Actualizar datos de un grupo
 export const updateGroupAction = createAsyncThunk<
   { message: string },
   { tenantId: string; groupSlug: string; updates: Partial<UpdateGroupDTO> },
   { rejectValue: { error: string } }
->("group/update", async ({ tenantId, groupSlug, updates }, { rejectWithValue }) => {
-  try {
-    console.log("Updating group with data:", { tenantId, groupSlug, updates });
-    const response = await updateGroup(tenantId, groupSlug, updates);
-    return response;
-  } catch (error: unknown) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as { error: string };
-    const errorMessage = errorData?.error || "Error al actualizar el grupo";
-    return rejectWithValue({ error: errorMessage });
+>(
+  "group/update",
+  async ({ tenantId, groupSlug, updates }, { rejectWithValue }) => {
+    try {
+      console.log("Updating group with data:", {
+        tenantId,
+        groupSlug,
+        updates,
+      });
+      const response = await updateGroup(tenantId, groupSlug, updates);
+      return response;
+    } catch (error: unknown) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as { error: string };
+      const errorMessage = errorData?.error || "Error al actualizar el grupo";
+      return rejectWithValue({ error: errorMessage });
+    }
   }
-});
+);
 
 // Crear un nuevo grupo
 export const createGroupAction = createAsyncThunk<
   { message: string; newGroup?: Group },
   CreateGroupRequest,
   { rejectValue: { error: string } }
->("group/create", async (groupData: CreateGroupRequest, { rejectWithValue }) => {
-  try {
-    const response = await createGroup(groupData);
+>(
+  "group/create",
+  async (groupData: CreateGroupRequest, { rejectWithValue }) => {
+    try {
+      const response = await createGroup(groupData);
 
-    return {
-      message: "Grupo creado exitosamente",
-      newGroup: response,
-    };
-  } catch (error: unknown) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as { error: string };
-    const errorMessage = errorData?.error || "Error al crear el grupo";
-    return rejectWithValue({ error: errorMessage });
+      return {
+        message: "Grupo creado exitosamente",
+        newGroup: response,
+      };
+    } catch (error: unknown) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as { error: string };
+      const errorMessage = errorData?.error || "Error al crear el grupo";
+      return rejectWithValue({ error: errorMessage });
+    }
   }
-});
+);
 
 // Stats de grupos
 
@@ -229,22 +256,31 @@ export const createGroupAdminAction = createAsyncThunk<
     };
   },
   { rejectValue: { error: string } }
->("groups/createAdmin", async ({ tenantId, slug, data }, { rejectWithValue }) => {
-  try {
-    const response = await createGroupAdmin(tenantId, slug, data);
-    return {
-      message: "Administrador de grupo creado exitosamente",
-      userId: response.userId,
-      email: response.email,
-      assignedRole: response.assignedRole,
-    };
-  } catch (error: unknown) {
-    const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as { error?: string; message?: string };
-    const errorMessage = errorData?.error || errorData?.message || "Error al crear el administrador de grupo";
-    return rejectWithValue({ error: errorMessage });
+>(
+  "groups/createAdmin",
+  async ({ tenantId, slug, data }, { rejectWithValue }) => {
+    try {
+      const response = await createGroupAdmin(tenantId, slug, data);
+      return {
+        message: "Administrador de grupo creado exitosamente",
+        userId: response.userId,
+        email: response.email,
+        assignedRole: response.assignedRole,
+      };
+    } catch (error: unknown) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as {
+        error?: string;
+        message?: string;
+      };
+      const errorMessage =
+        errorData?.error ||
+        errorData?.message ||
+        "Error al crear el administrador de grupo";
+      return rejectWithValue({ error: errorMessage });
+    }
   }
-});
+);
 
 // Crear administrador de grupo con conexión específica (usa la conexión correcta del grupo)
 export const createGroupAdminWithConnectionAction = createAsyncThunk<
@@ -260,19 +296,53 @@ export const createGroupAdminWithConnectionAction = createAsyncThunk<
     };
   },
   { rejectValue: { error: string } }
->("groups/createAdminWithConnection", async ({ tenantId, slug, data }, { rejectWithValue }) => {
+>(
+  "groups/createAdminWithConnection",
+  async ({ tenantId, slug, data }, { rejectWithValue }) => {
+    try {
+      const response = await createGroupAdminWithConnection(
+        tenantId,
+        slug,
+        data
+      );
+      return {
+        message: "Administrador de grupo creado exitosamente.",
+        userId: response.userId,
+        email: response.email,
+        assignedRole: response.assignedRole,
+      };
+    } catch (error: unknown) {
+      const axiosError = error as AxiosError;
+      const errorData = axiosError.response?.data as {
+        error?: string;
+        message?: string;
+      };
+      const errorMessage =
+        errorData?.error ||
+        errorData?.message ||
+        "Error al crear el administrador de grupo";
+      return rejectWithValue({ error: errorMessage });
+    }
+  }
+);
+
+// Validar slug de grupo
+export const validateGroupSlugAction = createAsyncThunk<
+  { slug: string; valid: boolean; reason: string | null; message: string | null },
+  { tenantId: string; slug: string },
+  { rejectValue: { error: string } }
+>("groups/validateSlug", async ({ tenantId, slug }, { rejectWithValue }) => {
   try {
-    const response = await createGroupAdminWithConnection(tenantId, slug, data);
-    return {
-      message: "Administrador de grupo creado exitosamente.",
-      userId: response.userId,
-      email: response.email,
-      assignedRole: response.assignedRole,
-    };
+    const response = await validateGroupSlug(tenantId, slug);
+    return response;
   } catch (error: unknown) {
     const axiosError = error as AxiosError;
-    const errorData = axiosError.response?.data as { error?: string; message?: string };
-    const errorMessage = errorData?.error || errorData?.message || "Error al crear el administrador de grupo";
+    const errorData = axiosError.response?.data as {
+      error?: string;
+      message?: string;
+    };
+    const errorMessage =
+      errorData?.error || errorData?.message || "Error al validar el slug";
     return rejectWithValue({ error: errorMessage });
   }
 });

--- a/frontend/src/store/groups/groupsActions.ts
+++ b/frontend/src/store/groups/groupsActions.ts
@@ -329,11 +329,11 @@ export const createGroupAdminWithConnectionAction = createAsyncThunk<
 // Validar slug de grupo
 export const validateGroupSlugAction = createAsyncThunk<
   { slug: string; valid: boolean; reason: string | null; message: string | null },
-  { tenantId: string; slug: string },
+  { slug: string },
   { rejectValue: { error: string } }
->("groups/validateSlug", async ({ tenantId, slug }, { rejectWithValue }) => {
+>("groups/validateSlug", async ({ slug }, { rejectWithValue }) => {
   try {
-    const response = await validateGroupSlug(tenantId, slug);
+    const response = await validateGroupSlug( slug);
     return response;
   } catch (error: unknown) {
     const axiosError = error as AxiosError;

--- a/frontend/src/store/groups/groupsSlice.ts
+++ b/frontend/src/store/groups/groupsSlice.ts
@@ -257,11 +257,11 @@ const groupsSlice = createSlice({
     });
     builder.addCase(validateGroupSlugAction.fulfilled, (state, action) => {
       state.slugValidation.isValidating = false;
-      // El backend devuelve "valid: true" cuando el slug está disponible
       state.slugValidation.isAvailable = action.payload.valid;
-      // Si hay un mensaje o reason de error, lo guardamos
-      if (action.payload.reason || action.payload.message) {
+      if (action.payload.valid === false && (action.payload.reason || action.payload.message)) {
         state.slugValidation.error = action.payload.reason || action.payload.message;
+      } else {
+        state.slugValidation.error = null;
       }
     });
     builder.addCase(validateGroupSlugAction.rejected, (state, action) => {

--- a/frontend/src/store/groups/groupsSlice.ts
+++ b/frontend/src/store/groups/groupsSlice.ts
@@ -12,6 +12,7 @@ import {
   fetchActiveGroupsCountAction,
   fetchInactiveGroupsCountAction,
   fetchTopGroupsByMembersAction,
+  validateGroupSlugAction,
 } from "./groupsActions";
 import type { GroupResponseDTO as Group, GroupMembersDTO, TopGroupByMembersDTO, GroupWithAdminBackendDTO } from "@/types/group.type";
 interface GroupsState {
@@ -26,6 +27,11 @@ interface GroupsState {
   activeGroupsCount: number;
   inactiveGroupsCount: number;
   topGroupsByMembers: TopGroupByMembersDTO[];
+  slugValidation: {
+    isValidating: boolean;
+    isAvailable: boolean | null;
+    error: string | null;
+  };
 }
 const initialState: GroupsState = {
   groups: [],
@@ -39,6 +45,11 @@ const initialState: GroupsState = {
   activeGroupsCount: 0,
   inactiveGroupsCount: 0,
   topGroupsByMembers: [],
+  slugValidation: {
+    isValidating: false,
+    isAvailable: null,
+    error: null,
+  },
 };
 
 
@@ -55,6 +66,13 @@ const groupsSlice = createSlice({
       state.group = null;
       state.error = null;
       state.message = "";
+    },
+    resetSlugValidation(state) {
+      state.slugValidation = {
+        isValidating: false,
+        isAvailable: null,
+        error: null,
+      };
     },
   },
   extraReducers: (builder) => {
@@ -230,7 +248,28 @@ const groupsSlice = createSlice({
       state.loading = false;
       state.error = action.payload?.error as string;
     });
+
+    // Validar slug de grupo
+    builder.addCase(validateGroupSlugAction.pending, (state) => {
+      state.slugValidation.isValidating = true;
+      state.slugValidation.error = null;
+      state.slugValidation.isAvailable = null;
+    });
+    builder.addCase(validateGroupSlugAction.fulfilled, (state, action) => {
+      state.slugValidation.isValidating = false;
+      // El backend devuelve "valid: true" cuando el slug está disponible
+      state.slugValidation.isAvailable = action.payload.valid;
+      // Si hay un mensaje o reason de error, lo guardamos
+      if (action.payload.reason || action.payload.message) {
+        state.slugValidation.error = action.payload.reason || action.payload.message;
+      }
+    });
+    builder.addCase(validateGroupSlugAction.rejected, (state, action) => {
+      state.slugValidation.isValidating = false;
+      state.slugValidation.error = action.payload?.error || "Error al validar slug";
+      state.slugValidation.isAvailable = false;
+    });
   },
 });
-export const { clearNotification, clearGroups } = groupsSlice.actions;
+export const { clearNotification, clearGroups, resetSlugValidation } = groupsSlice.actions;
 export default groupsSlice.reducer;

--- a/frontend/src/types/group.type.ts
+++ b/frontend/src/types/group.type.ts
@@ -26,6 +26,7 @@ export interface GroupResponseDTO {
 export interface CreateGroupDTO {
   groupId?: number;
   name: string;
+  slug: string;
   district?: string;
   identifierNumber?: string;
   address?: string;


### PR DESCRIPTION
# Feature: Admin Global - Mejoras en Gestión de Grupos

## Resumen

Esta PR introduce mejoras significativas en la funcionalidad de administración de grupos del módulo Admin Global, incluyendo validación de slug en tiempo real, mejoras en la UX de formularios, y correcciones de errores en la comunicación con el backend.

## Características Nuevas

### Validación de Slug en Tiempo Real

- **API**: Nueva función `validateGroupSlug()` que consulta al backend si un slug está disponible
- **Redux**: 
  - Nuevo action `validateGroupSlugAction` para manejar la validación asíncrona
  - Estado `slugValidation` en el slice con propiedades: `isValidating`, `isAvailable`, `error`
  - Reducer `resetSlugValidation` para limpiar el estado de validación
- **UX**: 
  - Validación con debounce (500ms) mientras el usuario escribe
  - Feedback visual inmediato (bordes rojo/verde según disponibilidad)
  - Mensajes descriptivos: "⏳ Validando...", "✓ Slug disponible", "❌ Este slug ya está en uso"
  - Validación de formato con regex: `^[a-z0-9]+(?:-[a-z0-9]+)*$`

### Campo Slug en CreateGroupModal

- Campo de slug **manual** (antes se generaba automáticamente)
- Validación en tiempo real integrada con Redux
- Campo obligatorio con validación de formato
- Texto de ayuda: "Solo letras minúsculas, números y guiones"

### Campo Slug en GroupEditModal

- Campo de slug agregado en modo **solo lectura**
- Texto de ayuda informativo sobre la inmutabilidad del slug
- Previene modificaciones accidentales después de la creación

## Correcciones

### Backend 500 Error - Conversión camelCase → snake_case

**Problema**: El backend rechazaba actualizaciones de grupos con error 500 porque esperaba propiedades en `snake_case` pero recibía `camelCase`.

**Solución**: Implementado mapper en `GroupEditModal.handleSave()`:
- `identifierNumber` → `identifier_number`
- `foundedIn` → `founded_in`
- `socialLinks` → `social_links`
- `isActive` → `is_active`

### Validación de Email

- Agregada validación de formato en **ambos modales** (crear y editar)
- Regex: `/^[^\s@]+@[^\s@]+\.[^\s@]+$/`
- Mensajes de error descriptivos

## Mejoras de UX

### Calendario de Fecha de Fundación

- **Dropdown de año/mes**: Cambio de `captionLayout` a `"dropdown"` para navegación más rápida
- **Rango ampliado**: `fromYear={1900}` hasta año actual
- Facilita selección de fechas antiguas para grupos históricos

### Accesibilidad

- Agregado `DialogDescription` en ambos modales (CreateGroupModal y GroupEditModal)
- Cumple con estándares ARIA para lectores de pantalla
- Elimina warnings de accesibilidad en la consola

### Reorganización de Campos

- **CreateGroupModal**:
  - Campo "Estado" movido antes de los campos de imágenes
  - Email marcado como obligatorio con asterisco (*)
  - Slug agregado como segundo campo (después del nombre)
  
- **GroupEditModal**:
  - Campo "Estado" reposicionado para consistencia con CreateGroupModal
  - Slug agregado en posición visible

## Cambios Técnicos

### Archivos Modificados

1. **`frontend/src/api/groupsApi.ts`**
   - Nueva función `validateGroupSlug(tenantId, slug)`
   - Tipo de retorno: `{ slug: string; valid: boolean; reason: string | null; message: string | null }`

2. **`frontend/src/store/groups/groupsActions.ts`** 
   - Nuevo thunk `validateGroupSlugAction`
   - Manejo de errores con `AxiosError`

3. **`frontend/src/store/groups/groupsSlice.ts`**
   - Estado `slugValidation` agregado al `GroupsState`
   - Reducer `resetSlugValidation`
   - ExtraReducers para manejar estados de validación (pending, fulfilled, rejected)
   - Exportación de nueva acción `resetSlugValidation`

4. **`frontend/src/app/routes/admin-global/Grupos/detalles/CreateGroupModal.tsx`** 
   - Hook `useGroup()` extendido para usar `slugValidation`
   - Función `validateSlug()` con debounce
   - Campo slug con validación visual
   - Validación completa antes de enviar formulario
   - DialogDescription agregado
   - Mejoras en Calendar component

5. **`frontend/src/app/routes/admin-global/Grupos/detalles/GroupEditModal.tsx`** 
   - Campo slug agregado (solo lectura)
   - Mapper camelCase → snake_case para actualizaciones
   - Validación de email agregada
   - DialogDescription agregado
   - Mejoras en Calendar component
   - Reorganización de campos

6. **`frontend/src/types/group.type.ts`** (+1 línea)
   - Soporte para propiedades en ambos formatos (camelCase y snake_case)

---
