### PR TITLE
fix: ajustar sidebar de Admin Global según tenant activo (ocultar Inicio/Grupos cuando no corresponde)

### DIFF
--- a/frontend/src/app/routes/dashboard/Dashboard.tsx
+++ b/frontend/src/app/routes/dashboard/Dashboard.tsx
@@ -8,21 +8,26 @@ import ComiteAdminView from "./components/ComiteAdminView";
 import ScouterView from "./components/ScouterView";
 import { FullScreenLoader } from "@/components/common/FullScreenLoader";
 import TesoreroView from "./components/TesoreroView";
+import { useTenantParams } from "../organigrama/organigramaRamas_Subramas/hooks/useTenantParams";
 
 
 export default function Dashboard() {
   const { currentUserRole, status } = useRoleContext();
+  const { tenantId } = useTenantParams();
 
   if (status === "loading" || status === "idle") {
     return <FullScreenLoader message="Estamos dejando todo listo para ti!" />;
   }
-
+  if (currentUserRole === RawRole.ADMIN_GLOBAL) {
+    const userTenantClaim = import.meta.env.VITE_ADMIN_ORGANIZATION_ID;
+    if (tenantId && userTenantClaim && tenantId === userTenantClaim) {
+      return <AdminGlobalView />;
+    }
+    return <AdminGrupoView />;
+  }
 
   // Solo se renderiza Y ejecuta el componente correspondiente al rol del usuario
   switch (currentUserRole) {
-    case RawRole.ADMIN_GLOBAL:
-      return <AdminGlobalView />;
-
     case RawRole.ADMIN_GRUPO:
       return <AdminGrupoView />;
 

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -47,6 +47,7 @@ import { setAuth0TokenProvider } from "@/api/axios";
 import { useEffect } from "react";
 import * as React from "react";
 import { useGroupInfo } from "@/hooks/useGroupInfo";
+import { useTenantParams } from '@/app/routes/organigrama/organigramaRamas_Subramas/hooks/useTenantParams';
 
 type SubMenuItem = {
   id: string;
@@ -278,9 +279,19 @@ function AppLayoutContent() {
   const { status, currentUserRole, currentUserRoleLabel, error, retry } =
     useRoleContext();
   const { groupName, loading: groupLoading } = useGroupInfo();
+  const { tenantId } = useTenantParams();
 
   // Determinar qué menú mostrar según el rol del usuario
   const getMenuItems = (): MenuItem[] => {
+        if (currentUserRole === RawRole.ADMIN_GLOBAL) {
+          const userTenantClaim =
+            import.meta.env.VITE_ADMIN_ORGANIZATION_ID;
+          if (tenantId && userTenantClaim && tenantId === userTenantClaim) {
+            return adminGlobalItems.filter((it) => it.id === "inicio" || it.id === "grupos");
+          }
+          return adminGlobalItems.filter((it) => it.id !== "grupos");;
+        }
+
     switch (currentUserRole) {
       case RawRole.ACUDIENTE:
         return acudienteItems;
@@ -294,8 +305,6 @@ function AppLayoutContent() {
         return comiteItems;
       case RawRole.ADMIN_GRUPO:
         return adminGrupalItems;
-      case RawRole.ADMIN_GLOBAL:
-        return adminGlobalItems;
       default:
         return ScoutItems;
     }


### PR DESCRIPTION
Ajusta la navegación lateral para usuarios con rol Admin Global: cuando el tenant activo no es la organización admin (según VITE_ADMIN_ORGANIZATION_ID) se ocultan los items "Inicio" y "Grupos". Cuando el Admin Global está en su tenant propio solo se muestran "Inicio" y "Grupos".