### PR TITLE
cambio en las exportaciones del pdf de organigrama

### DIFF
--- a/frontend/src/app/routes/organigrama/organigramaNivelesOrganizativos/components/ExportMenu.tsx
+++ b/frontend/src/app/routes/organigrama/organigramaNivelesOrganizativos/components/ExportMenu.tsx
@@ -12,42 +12,36 @@ import { getGroupBySlug } from "@/api/organigramaApi";
 import { useTenantParams } from "../../organigramaRamas_Subramas/hooks/useTenantParams";
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
-import KNUT from "@/assets/KNUT.png";
 
 /* ============================================================
    📄 Exportación a PDF
    ============================================================ */
 // Util para cargar una imagen desde un URL (manejado por Vite) y esperar a que esté lista
-function loadImage(src: string): Promise<HTMLImageElement> {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.onload = () => resolve(img);
-    img.onerror = reject;
-    img.src = src;
-  });
+// Footer: dibuja línea y la marca KNUT en cada página
+function drawKnutFooter(doc: jsPDF, color: [number, number, number] = [26, 65, 52]) {
+  const getPages = (doc as unknown as { getNumberOfPages?: () => number; internal?: { getNumberOfPages?: () => number } })
+    .getNumberOfPages?.bind(doc)
+    ?? (doc as unknown as { internal?: { getNumberOfPages?: () => number } })
+      .internal?.getNumberOfPages?.bind((doc as unknown as { internal?: { getNumberOfPages?: () => number } }).internal)
+    ?? (() => 1);
+  const total = Math.max(1, getPages());
+  for (let i = 1; i <= total; i++) {
+    doc.setPage(i);
+    const pw = doc.internal.pageSize.getWidth();
+    const ph = doc.internal.pageSize.getHeight();
+    const marginX = 14;
+    const y = ph - 24;
+    doc.setDrawColor(...color);
+    doc.setLineWidth(1);
+    doc.line(marginX, y, pw - marginX, y);
+    doc.setFont("helvetica", "bold");
+    doc.setTextColor(...color);
+    doc.setFontSize(10);
+    doc.text("KNUT", pw - marginX, y + 12, { align: "right" as const });
+  }
 }
 
-// Typesafe helpers for jspdf quirks
-type JsPDFMaybePaged = jsPDF & {
-  getNumberOfPages?: () => number;
-  internal?: { getNumberOfPages?: () => number; pageSize: { getWidth: () => number; getHeight: () => number } };
-};
-type JsPDFWithAddImage = jsPDF & {
-  addImage: (
-    imageData: HTMLImageElement | string,
-    format: string,
-    x: number,
-    y: number,
-    w: number,
-    h: number,
-    alias?: string,
-    compression?: "NONE" | "FAST" | "SLOW"
-  ) => jsPDF;
-};
-const getNumberOfPagesSafe = (doc: jsPDF): number => {
-  const d = doc as unknown as JsPDFMaybePaged;
-  return d.getNumberOfPages?.() ?? d.internal?.getNumberOfPages?.() ?? 1;
-};
+// Nota: omitimos helpers de imagen y número de páginas heredados; ahora dibujamos footer por página
 
 async function exportPDF(data: OrganigramaNiveles, members?: Member[], groupName?: string) {
   const doc = new jsPDF();
@@ -150,24 +144,14 @@ async function exportPDF(data: OrganigramaNiveles, members?: Member[], groupName
       });
     }
   });
-  // Precalcular tamaño del footer (no reservamos margen global)
-  let footerW = 110;
-  let footerH = 45;
-  try {
-    const probe = await loadImage(KNUT);
-    const pageW = doc.internal.pageSize.getWidth();
-    footerW = Math.min(120, pageW * 0.28);
-    const ratio = probe.height > 0 ? probe.height / probe.width : 0.45;
-    footerH = footerW * ratio;
-  } catch {/* default sizes */}
+  // Reservar margen inferior para no solapar el pie de página
 
   autoTable(doc, {
     head: [["Nivel", "Cargo", "Titular", "Descripción"]],
     body: tableData,
     startY: 35,
-  // Importante: no reservar margen grande en todas las páginas;
-  // dejamos un margen pequeño y gestionamos el pie solo en la última página.
-  margin: { bottom: 12 },
+    // Reservar espacio inferior para el pie de página (línea + KNUT)
+    margin: { bottom: 32 },
     theme: "striped",
     styles: {
       fontSize: 9,
@@ -180,44 +164,10 @@ async function exportPDF(data: OrganigramaNiveles, members?: Member[], groupName
       fontStyle: "bold",
     },
     alternateRowStyles: { fillColor: [237, 237, 237] }, // 🎨 --accent (#EDEDED)
+    didDrawPage: () => {
+      drawKnutFooter(doc);
+    },
   });
-
-  // Pie de página: solo en la última página y sin dejar espacio en las demás.
-  try {
-    const img = await loadImage(KNUT);
-    const pageCount: number = getNumberOfPagesSafe(doc);
-    // Colocar el logo solo en la última página; si no hay espacio, crear una nueva
-    const last = Math.max(1, pageCount);
-    const anyDoc = doc as unknown as { lastAutoTable?: { finalY: number } };
-    doc.setPage(last);
-    const pageWidth = doc.internal.pageSize.getWidth();
-    const pageHeight = doc.internal.pageSize.getHeight();
-    const margin = 16; // margen inferior
-    const w = Math.min(footerW, pageWidth * 0.28);
-    const ratio = img.height > 0 ? img.height / img.width : footerH / Math.max(footerW, 1);
-    const h = w * ratio;
-    const x = (pageWidth - w) / 2;
-    const y = pageHeight - h - margin;
-
-    // Verificar posible solapamiento con el contenido del último autoTable
-    const finalY = anyDoc.lastAutoTable?.finalY ?? 0;
-    if (finalY && finalY > y - 4) {
-      // No hay espacio suficiente: agregar una página extra para el logo
-      doc.addPage();
-      const pw = doc.internal.pageSize.getWidth();
-      const ph = doc.internal.pageSize.getHeight();
-      const w2 = Math.min(footerW, pw * 0.28);
-      const h2 = w2 * ratio;
-      const x2 = (pw - w2) / 2;
-      const y2 = ph - h2 - margin;
-      (doc as unknown as JsPDFWithAddImage).addImage(img, "PNG", x2, y2, w2, h2, undefined, "FAST");
-    } else {
-      // Hay espacio en la última página actual
-      (doc as unknown as JsPDFWithAddImage).addImage(img, "PNG", x, y, w, h, undefined, "FAST");
-    }
-  } catch (e) {
-    console.warn("[Export PDF Niveles] No se pudo cargar la imagen de pie de página KNUT:", e);
-  }
 
   doc.save(`organigrama_niveles_${data.anio}.pdf`);
 }

--- a/frontend/src/app/routes/organigrama/organigramaRamas_Subramas/utils/exportarOrganigrama.ts
+++ b/frontend/src/app/routes/organigrama/organigramaRamas_Subramas/utils/exportarOrganigrama.ts
@@ -4,14 +4,6 @@ import type { Branch as Rama, Subgroup as Subrama } from "../types/frontend";
 import { store } from "@/store/store";
 import { fetchSubgroupMembersAction } from "@/store/organigrama/organigramaActions";
 import { getMemberFullName, isMemberActiveAndApproved, isMemberScouter } from "@/hooks/useSubgroupMembers";
-import KNUT from "@/assets/KNUT.png";
-// Simple loader to get image dimensions and use as footer
-const loadImage = (src: string) => new Promise<HTMLImageElement>((resolve, reject) => {
-  const img = new Image();
-  img.onload = () => resolve(img);
-  img.onerror = reject;
-  img.src = src;
-});
 
 // Helper functions to filter out committee branches
 const stripAccents = (s: string) => s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
@@ -44,6 +36,32 @@ function hexToRgb(hex: string): [number, number, number] {
   return [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)];
 }
 
+// Dibuja el pie de página requerido: línea horizontal y texto "KNUT" a la derecha en cada página
+function drawKnutFooter(doc: jsPDF, colorHex = "#1A4134") {
+  const [r, g, b] = hexToRgb(colorHex);
+  // getNumberOfPages es inconsistente entre versiones; cubrir ambos casos
+  const getPages = (doc as unknown as { getNumberOfPages?: () => number; internal?: { getNumberOfPages?: () => number } })
+    .getNumberOfPages?.bind(doc)
+    ?? (doc as unknown as { internal?: { getNumberOfPages?: () => number } })
+      .internal?.getNumberOfPages?.bind((doc as unknown as { internal?: { getNumberOfPages?: () => number } }).internal)
+    ?? (() => 1);
+  const total = Math.max(1, getPages());
+  for (let i = 1; i <= total; i++) {
+    doc.setPage(i);
+    const pw = doc.internal.pageSize.getWidth();
+    const ph = doc.internal.pageSize.getHeight();
+    const marginX = 40; // consistente con márgenes de contenido
+    const lineY = ph - 28; // altura de la línea
+    doc.setDrawColor(r, g, b);
+    doc.setLineWidth(1);
+    doc.line(marginX, lineY, pw - marginX, lineY);
+    // Marca "KNUT" alineada a la derecha, debajo de la línea
+    doc.setFont("helvetica", "bold");
+    doc.setTextColor(r, g, b);
+    doc.setFontSize(10);
+    doc.text("KNUT", pw - marginX, lineY + 14, { align: "right" as const });
+  }
+}
 
 
 
@@ -279,14 +297,6 @@ export const exportarOrganigramaPDF = async (ramas: Rama[], opts: ExportPDFOpts 
 
     console.log(' [ExportPDF] Generando tabla con autoTable...');
     const pageW = doc.internal.pageSize.getWidth();
-    // Precalcular dimensiones del pie de página (logo); no reservaremos margen global
-  const footerW = Math.min(120, pageW * 0.18);
-    let footerH = 50;
-    try {
-      const probe = await loadImage(KNUT);
-      const ratio = probe.height > 0 ? probe.height / probe.width : 0.45;
-      footerH = footerW * ratio;
-    } catch { /* keep defaults */ }
     const availableW = pageW - x * 2;
     const updatedWeights = [10, 14, 16, 48, 12]; 
     const totalW = updatedWeights.reduce((a, b) => a + b, 0);
@@ -298,8 +308,8 @@ export const exportarOrganigramaPDF = async (ramas: Rama[], opts: ExportPDFOpts 
       startY: y + 32,
       head: [["Rama", "Descripción", "NombreSubrama", "Integrantes", "JefeRama"]],
       body,
-      // Usar un margen inferior pequeño para no reservar espacio en todas las páginas
-      margin: { left: x, right: x, bottom: 12 },
+      // Reservar un poco de espacio inferior para la línea y el texto del pie de página
+      margin: { left: x, right: x, bottom: 36 },
       styles: { 
         fontSize: 8, 
         cellPadding: 4, 
@@ -310,42 +320,10 @@ export const exportarOrganigramaPDF = async (ramas: Rama[], opts: ExportPDFOpts 
       headStyles: { fillColor: [r, g, b], textColor: [255, 255, 255] },
       columnStyles: finalColumnStyles,
       didDrawPage: () => {
-        // Reservado si deseamos dibujar elementos en cada página durante la generación
+        // Dibujar el pie de página en cada página durante el render
+        drawKnutFooter(doc, opts.colorHex ?? "#1A4134");
       },
     });
-
-    // Pie de página solo en la última página; si no hay espacio, crear una nueva página
-    try {
-      const img = await loadImage(KNUT);
-      const getPages = (doc as unknown as { getNumberOfPages?: () => number; internal?: { getNumberOfPages?: () => number } }).getNumberOfPages?.bind(doc) ?? (doc as unknown as { internal?: { getNumberOfPages?: () => number } }).internal?.getNumberOfPages?.bind((doc as unknown as { internal?: { getNumberOfPages?: () => number } }).internal) ?? (() => 1);
-      const last = Math.max(1, getPages());
-      const anyDoc = doc as unknown as { lastAutoTable?: { finalY: number } };
-      doc.setPage(last);
-      const pageWidth = doc.internal.pageSize.getWidth();
-      const pageHeight = doc.internal.pageSize.getHeight();
-      const marginBottom = 18;
-      const w = Math.min(footerW, pageWidth * 0.18);
-      const ratio = img.height > 0 ? img.height / img.width : footerH / Math.max(footerW, 1);
-      const h = w * ratio;
-      const xImg = (pageWidth - w) / 2;
-      const yImg = pageHeight - h - marginBottom;
-      const finalY = anyDoc.lastAutoTable?.finalY ?? 0;
-      if (finalY && finalY > yImg - 4) {
-        // Sin espacio: crear una página más para el logo
-        doc.addPage();
-        const pw = doc.internal.pageSize.getWidth();
-        const ph = doc.internal.pageSize.getHeight();
-        const w2 = Math.min(footerW, pw * 0.18);
-        const h2 = w2 * ratio;
-        const x2 = (pw - w2) / 2;
-        const y2 = ph - h2 - marginBottom;
-        (doc as unknown as { addImage: (imageData: HTMLImageElement | string, format: string, x: number, y: number, w: number, h: number, alias?: string, compression?: "NONE" | "FAST" | "SLOW") => jsPDF }).addImage(img, "PNG", x2, y2, w2, h2, undefined, "FAST");
-      } else {
-        (doc as unknown as { addImage: (imageData: HTMLImageElement | string, format: string, x: number, y: number, w: number, h: number, alias?: string, compression?: "NONE" | "FAST" | "SLOW") => jsPDF }).addImage(img, "PNG", xImg, yImg, w, h, undefined, "FAST");
-      }
-    } catch (e) {
-      console.warn(" [ExportPDF] No se pudo agregar imagen de pie de página KNUT:", e);
-    }
 
     console.log(' [ExportPDF] Guardando archivo organigrama.pdf...');
     doc.save("organigrama.pdf");

--- a/frontend/src/app/routes/organigrama/utils/exportOrgChartCombined.ts
+++ b/frontend/src/app/routes/organigrama/utils/exportOrgChartCombined.ts
@@ -2,15 +2,30 @@ import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
 import type { OrganigramaNiveles } from "../organigramaNivelesOrganizativos/types/niveles.types";
 import type { Member } from "@/types/member.type";
-import KNUT from "@/assets/KNUT.png";
 
-// Image loader to compute footer size
-const loadImage = (src: string) => new Promise<HTMLImageElement>((resolve, reject) => {
-  const img = new Image();
-  img.onload = () => resolve(img);
-  img.onerror = reject;
-  img.src = src;
-});
+// Footer: dibuja línea y la marca KNUT en cada página
+function drawKnutFooter(doc: jsPDF, color: [number, number, number] = [26, 65, 52]) {
+  const getPages = (doc as unknown as { getNumberOfPages?: () => number; internal?: { getNumberOfPages?: () => number } })
+    .getNumberOfPages?.bind(doc)
+    ?? (doc as unknown as { internal?: { getNumberOfPages?: () => number } })
+      .internal?.getNumberOfPages?.bind((doc as unknown as { internal?: { getNumberOfPages?: () => number } }).internal)
+    ?? (() => 1);
+  const total = Math.max(1, getPages());
+  for (let i = 1; i <= total; i++) {
+    doc.setPage(i);
+    const pw = doc.internal.pageSize.getWidth();
+    const ph = doc.internal.pageSize.getHeight();
+    const marginX = 40;
+    const y = ph - 28;
+    doc.setDrawColor(...color);
+    doc.setLineWidth(1);
+    doc.line(marginX, y, pw - marginX, y);
+    doc.setFont("helvetica", "bold");
+    doc.setTextColor(...color);
+    doc.setFontSize(10);
+    doc.text("KNUT", pw - marginX, y + 14, { align: "right" as const });
+  }
+}
 
 type BranchLite = {
   id: string | number;
@@ -279,16 +294,7 @@ export async function exportOrgChartCombinedPDF(
   const doc = new jsPDF({ unit: "pt", format: "a4", orientation: "landscape" });
   const x = 40;
   let y = 50;
-  // Pre-calc footer dimensions (no reservaremos margen global en todas las páginas)
-  const pageWidth0 = doc.internal.pageSize.getWidth();
-  const footerW = Math.min(140, pageWidth0 * 0.18);
-  let footerH = 56;
-  let footerImg: HTMLImageElement | undefined;
-  try {
-    footerImg = await loadImage(KNUT);
-    const ratio = footerImg.height > 0 ? footerImg.height / footerImg.width : 0.4;
-    footerH = footerW * ratio;
-  } catch { /* keep defaults */ }
+  // Reservaremos margen inferior vía autoTable; el pie se dibuja por página
 
   // Title
   doc.setFont("helvetica", "bold");
@@ -415,10 +421,13 @@ export async function exportOrgChartCombinedPDF(
     startY: y + 10,
     head: [["Rama", "Descripción", "NombreSubrama", "Integrantes", "JefeRama"]],
     body: branchesBody,
-    // Margen inferior pequeño para no reservar espacio en todas las páginas
-    margin: { left: x, right: x, bottom: 12 },
+    // Reservar espacio para footer (línea + "KNUT")
+    margin: { left: x, right: x, bottom: 36 },
     styles: { fontSize: 8, cellPadding: 4, overflow: "linebreak" },
     headStyles: { fillColor: [26, 65, 52], textColor: [255, 255, 255] },
+    didDrawPage: () => {
+      drawKnutFooter(doc);
+    },
   });
 
   const anyDoc = doc as unknown as { lastAutoTable?: { finalY: number } };
@@ -509,43 +518,14 @@ export async function exportOrgChartCombinedPDF(
     startY: y + 10,
     head: [["Nivel", "Cargo", "Titular", "Descripción"]],
     body: levelsBody,
-    // Margen inferior pequeño para no reservar espacio en todas las páginas
-    margin: { left: x, right: x, bottom: 12 },
+    // Reservar espacio para footer (línea + "KNUT")
+    margin: { left: x, right: x, bottom: 36 },
     styles: { fontSize: 8, cellPadding: 4, overflow: "linebreak" },
     headStyles: { fillColor: [26, 65, 52], textColor: [255, 255, 255] },
+    didDrawPage: () => {
+      drawKnutFooter(doc);
+    },
   });
-
-  // Pie de página solo en la última página; si no hay espacio, crear una nueva
-  try {
-    const img = footerImg ?? await loadImage(KNUT);
-    const getPages = (doc as unknown as { getNumberOfPages?: () => number; internal?: { getNumberOfPages?: () => number } }).getNumberOfPages?.bind(doc) ?? (doc as unknown as { internal?: { getNumberOfPages?: () => number } }).internal?.getNumberOfPages?.bind((doc as unknown as { internal?: { getNumberOfPages?: () => number } }).internal) ?? (() => 1);
-    const last = Math.max(1, getPages());
-    const anyDoc = doc as unknown as { lastAutoTable?: { finalY: number } };
-    doc.setPage(last);
-    const pageWidth = doc.internal.pageSize.getWidth();
-    const pageHeight = doc.internal.pageSize.getHeight();
-    const margin = 18;
-    const w = Math.min(footerW, pageWidth * 0.18);
-    const ratio = img.height > 0 ? img.height / img.width : footerH / Math.max(footerW, 1);
-    const h = w * ratio;
-    const xImg = (pageWidth - w) / 2;
-    const yImg = pageHeight - h - margin;
-    const finalY = anyDoc.lastAutoTable?.finalY ?? 0;
-    if (finalY && finalY > yImg - 4) {
-      doc.addPage();
-      const pw = doc.internal.pageSize.getWidth();
-      const ph = doc.internal.pageSize.getHeight();
-      const w2 = Math.min(footerW, pw * 0.18);
-      const h2 = w2 * ratio;
-      const x2 = (pw - w2) / 2;
-      const y2 = ph - h2 - margin;
-      (doc as unknown as { addImage: (imageData: HTMLImageElement | string, format: string, x: number, y: number, w: number, h: number, alias?: string, compression?: "NONE" | "FAST" | "SLOW") => jsPDF }).addImage(img, "PNG", x2, y2, w2, h2, undefined, "FAST");
-    } else {
-      (doc as unknown as { addImage: (imageData: HTMLImageElement | string, format: string, x: number, y: number, w: number, h: number, alias?: string, compression?: "NONE" | "FAST" | "SLOW") => jsPDF }).addImage(img, "PNG", xImg, yImg, w, h, undefined, "FAST");
-    }
-  } catch (e) {
-    console.warn("[Export PDF OrgChart] No se pudo cargar la imagen de pie de página KNUT:", e);
-  }
 
   doc.save(`organigrama_completo_${opts?.year ?? ""}.pdf`);
 }


### PR DESCRIPTION
  
This pull request refactors the PDF export functionality across several organigram-related files to simplify and standardize the way the footer is rendered. The main change is replacing the previous approach of dynamically loading and placing the KNUT logo image as a footer with a programmatic footer that draws a horizontal line and the text "KNUT" on every page. This results in more reliable, consistent, and faster PDF generation, and eliminates the need for image loading and space calculations for the logo.

Key changes by theme:

### PDF Footer Refactor

* Replaces the image-based KNUT logo footer with a programmatic footer: a horizontal line and the text "KNUT" drawn on every page, implemented via a new `drawKnutFooter` function in all relevant export files. This removes all code related to loading, sizing, and conditionally placing the image in the footer. [[1]](diffhunk://#diff-88ce3d299565892ebd7e9688998aa129fd6b4069ec2ecadda4a0e6a682998084L15-R44) [[2]](diffhunk://#diff-ccb6c56f54ca61ab702b908aaf281f5bd5b647fae4d3767789f014dd3ad62930R39-R64) [[3]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL5-R28)

* Ensures the new footer is rendered on every page by hooking `drawKnutFooter` into the `didDrawPage` callback of `jspdf-autotable` in all PDF export functions. [[1]](diffhunk://#diff-88ce3d299565892ebd7e9688998aa129fd6b4069ec2ecadda4a0e6a682998084R167-L221) [[2]](diffhunk://#diff-ccb6c56f54ca61ab702b908aaf281f5bd5b647fae4d3767789f014dd3ad62930L313-L349) [[3]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL418-R430) [[4]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL512-L549)

### Margin and Layout Adjustments

* Increases the bottom margin in all autoTable configurations to reserve space for the new footer, ensuring table content does not overlap with the footer line and text. [[1]](diffhunk://#diff-88ce3d299565892ebd7e9688998aa129fd6b4069ec2ecadda4a0e6a682998084L153-R154) [[2]](diffhunk://#diff-ccb6c56f54ca61ab702b908aaf281f5bd5b647fae4d3767789f014dd3ad62930L301-R312) [[3]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL418-R430) [[4]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL512-L549)

### Code Cleanup

* Removes all image loading helpers, image dimension calculations, and logic for conditionally adding the logo image only to the last page or creating an extra page for the logo if needed, as these are no longer necessary. [[1]](diffhunk://#diff-88ce3d299565892ebd7e9688998aa129fd6b4069ec2ecadda4a0e6a682998084L15-R44) [[2]](diffhunk://#diff-ccb6c56f54ca61ab702b908aaf281f5bd5b647fae4d3767789f014dd3ad62930L7-L14) [[3]](diffhunk://#diff-ccb6c56f54ca61ab702b908aaf281f5bd5b647fae4d3767789f014dd3ad62930L282-L289) [[4]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL5-R28) [[5]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL282-R297) [[6]](diffhunk://#diff-54d18a9fe8f6d24330399c61810137e9141b7e6b5e0cb3a5bfaad06004b00f1aL512-L549)

These changes make the PDF export more robust and maintainable, and ensure a consistent footer appearance across all generated PDFs.
