### PR TITLE
chore: hide social media links empty

### DIFF
--- a/frontend/src/components/groups/ScoutGroupCard.tsx
+++ b/frontend/src/components/groups/ScoutGroupCard.tsx
@@ -68,7 +68,9 @@ export const ScoutGroupCard = memo(function ScoutGroupCard({ group }: ScoutGroup
   // Memoizar redes sociales
   const socialLinksEntries = useMemo(() => {
     if (!groupData.socialLinks || typeof groupData.socialLinks !== 'object') return [];
-    return Object.entries(groupData.socialLinks);
+    return Object.entries(groupData.socialLinks).filter(([_platform, url]) => {
+      return typeof url === 'string' && url.trim() !== '';
+    });
   }, [groupData.socialLinks]);
 
   return (

--- a/frontend/src/components/groups/ScoutGroupCard.tsx
+++ b/frontend/src/components/groups/ScoutGroupCard.tsx
@@ -68,7 +68,7 @@ export const ScoutGroupCard = memo(function ScoutGroupCard({ group }: ScoutGroup
   // Memoizar redes sociales
   const socialLinksEntries = useMemo(() => {
     if (!groupData.socialLinks || typeof groupData.socialLinks !== 'object') return [];
-    return Object.entries(groupData.socialLinks).filter(([_platform, url]) => {
+    return Object.entries(groupData.socialLinks).filter(([, url]) => {
       return typeof url === 'string' && url.trim() !== '';
     });
   }, [groupData.socialLinks]);


### PR DESCRIPTION
ajusta las cards de grupos para no mostrar los social links que están vacios